### PR TITLE
Add equivalence check to "done" workflow

### DIFF
--- a/blossom/api/views.py
+++ b/blossom/api/views.py
@@ -326,6 +326,14 @@ class SubmissionViewSet(viewsets.ModelViewSet, RequestDataMixin, VolunteerMixin)
                 f"Submission ID {p.submission_id} has not yet been claimed!",
                 status.HTTP_412_PRECONDITION_FAILED,
             )
+
+        if p.claimed_by != v:
+            return build_response(
+                ERROR,
+                f"Submission ID {p.submission_id} is claimed by {p.claimed_by}!",
+                status.HTTP_412_PRECONDITION_FAILED
+            )
+
         p.completed_by = v
         p.complete_time = timezone.now()
         p.save()

--- a/blossom/tests/api/test_submissions.py
+++ b/blossom/tests/api/test_submissions.py
@@ -262,6 +262,28 @@ class TestSubmissionDone:
             "Submission ID AAA has not yet been claimed!"
         )
 
+    def test_done_different_claim(self, client):
+        client, headers = create_staff_volunteer_with_keys(client)
+        claiming_user = create_test_user()
+        submission = create_test_submission()
+        user = BlossomUser.objects.get(id=1)
+        submission.claimed_by = claiming_user
+        submission.save()
+
+        data = {"v_id": user.id}
+
+        result = client.post(
+            reverse("submission-done", host="api", args=[1]),
+            json.dumps(data),
+            HTTP_HOST="api",
+            content_type="application/json",
+            **headers,
+        )
+        assert result.status_code == 412
+        assert result.json().get("message") == (
+            f"Submission ID AAA is claimed by {claiming_user.username}!"
+        )
+
     def test_done_without_user_info(self, client):
         client, headers = create_staff_volunteer_with_keys(client)
         create_test_submission()


### PR DESCRIPTION
Relevant issue: #13 

## Description:

Check to the "done" method which verifies that the person who completed the transcription is equal to the one that has claimed the transcription.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [x] Wiki Documentation (if applicable)
