### PR TITLE
Use latest pycodestyle version for static analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         create_virtualenvs: true
     - name: Install Dependencies
-      run:|
+      run: |
         sudo apt-get install libjpeg8 libjpeg-dev libpng-dev libpq-dev git -y
         poetry install
     - name: Clone pyflakes repository


### PR DESCRIPTION
This PR adjusts the static analysis job to also use the master branch of `pycodestyle`. This is because the current latest version in pip provides false positives for assignment expressions.
