### PR TITLE
Update Static Analysis to use the correct diff

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         create_virtualenvs: true
     - name: Install Dependencies
       run: |
-        sudo apt-get install libjpeg8 libjpeg-dev libpng-dev libpq-dev git jq -y
+        sudo apt-get install libjpeg8 libjpeg-dev libpng-dev libpq-dev git -y
         poetry install
     - name: Clone pyflakes repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Before this PR, the static analysis did not check the difference compared to the base branch/commit, but instead it did not check anything. This PR aims to fix this by comparing the latest PR commit to the base commit and using `flake8` on this difference.