### PR TITLE
make precommit actually run everything

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
     rev: v2.3.0
     hooks:
     - id: flake8
+      additional_dependencies: [
+        "flake8-annotations==2.0.1",
+        "flake8-black==0.1.1",
+        "flake8-docstrings==1.5.0",
+        "flake8-import-order==0.18.1",
+        "flake8-variables-names==0.0.3"
+      ]


### PR DESCRIPTION
## Description:

Because of the way that pre-commit is built (namely that it uses its own venv), there is no way to use flake8 plugins from the main venv. The accepted answer is to move them / copy them into the pre-commit venv using the `additional_dependencies` section. This PR adds our current set of plugins and is tested working. 