### PR TITLE
update method to always trigger on first five transcriptions

### DIFF
--- a/api/tests/submissions/test_submission_done.py
+++ b/api/tests/submissions/test_submission_done.py
@@ -115,7 +115,8 @@ class TestSubmissionDone:
     @pytest.mark.parametrize(
         "probability,gamma,message,tor_url,trans_url",
         [
-            (0.8, 0, False, None, None),
+            (1, 3, False, None, None),
+            (0.8, 25, False, None, None),
             (0.7999, 50, True, None, None),
             (0.7, 51, False, None, None),
             (0.6999, 100, True, None, None),

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -217,7 +217,8 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         This is based on the gamma of the user. Given this gamma, a probability
         for the check is provided. The following probabilities are in use:
 
-        - gamma <= 50:              0.8
+        - gamma <= 5:               1
+        - 5 < gamma <= 50:          0.8
         - 50 < gamma <= 100:        0.7
         - 100 < gamma <= 250:       0.6
         - 250 < gamma <= 500:       0.5
@@ -226,9 +227,10 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         - 5000 < gamma:             0.05
 
         :param volunteer:   the volunteer for which the post should be checked
-        :return:            whether the post has to be checked
+        :return:            whether the post should be checked
         """
         probabilities = [
+            (5, 1),
             (50, 0.8),
             (100, 0.7),
             (250, 0.6),


### PR DESCRIPTION
Relevant issue: None

## Description:

A lot of the issues that we detect in volunteer transcriptions are in the first few transcriptions that they do, so I've updated the function to always send the first five transcriptions completed to slack.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
