### PR TITLE
Add additional endpoint for handling extra submissions

### DIFF
--- a/api/tests/submissions/test_submission_done.py
+++ b/api/tests/submissions/test_submission_done.py
@@ -186,7 +186,7 @@ class TestSubmissionDone:
             if message:
                 assert (
                     call(channel="#transcription_check", text=slack_message)
-                    == slack_client.chat_postMessage.call_args_list[-1]
+                    == slack_client.chat_postMessage.call_args_list[0]
                 )
             else:
                 assert slack_client.chat_postMessage.call_count == 0

--- a/api/tests/submissions/test_submission_yeet.py
+++ b/api/tests/submissions/test_submission_yeet.py
@@ -1,0 +1,79 @@
+import json
+from uuid import uuid4
+
+from django.test import Client
+from django.urls import reverse
+from rest_framework import status
+
+from api.models import Submission
+from api.tests.helpers import create_submission, setup_user_client
+
+
+class TestSubmissionYeet:
+    """Tests validating the behavior of the Submission yeetal process."""
+
+    def test_yeet(self, client: Client) -> None:
+        """Verify that listing all submissions works correctly."""
+        client, headers, user = setup_user_client(client)
+
+        # this matches how the dummy submissions are created
+        for _ in range(3):
+            create_submission(original_id=str(uuid4()), completed_by=user)
+
+        assert Submission.objects.count() == 3
+
+        data = {"username": user.username, "count": 2}
+
+        result = client.post(
+            reverse("submission-yeet"),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        assert result.status_code == status.HTTP_200_OK
+        assert Submission.objects.count() == 1
+
+    def test_yeet_more_requested_than_available(self, client: Client) -> None:
+        """Verify that requesting yeeting more submissions than available is okay."""
+        client, headers, user = setup_user_client(client)
+        create_submission(original_id=str(uuid4()), completed_by=user)
+        assert Submission.objects.count() == 1
+
+        data = {"username": user.username, "count": 10}
+
+        client.post(
+            reverse("submission-yeet"),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        assert Submission.objects.count() == 0
+
+    def test_yeet_with_no_count(self, client: Client) -> None:
+        """Verify that yeeting without a count only deletes one."""
+        client, headers, user = setup_user_client(client)
+        for _ in range(4):
+            create_submission(original_id=str(uuid4()), completed_by=user)
+        assert Submission.objects.count() == 4
+
+        data = {"username": user.username}
+
+        client.post(
+            reverse("submission-yeet"),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        assert Submission.objects.count() == 3
+
+    def test_yeet_with_no_user(self, client: Client) -> None:
+        """Verify that yeeting without a count only deletes one."""
+        client, headers, user = setup_user_client(client)
+
+        response = client.post(
+            reverse("submission-yeet"), content_type="application/json", **headers
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
Relevant issue: N/A

## Description:

While verifying the dummy transcriptions created by the bootstrap script, it looks like there are a handful of users who have _more_ dummy transcriptions than they should. This adds an endpoint that I can use to clean up dummy transcriptions with appropriate tests.

Also fixes single piece of feedback from #115 with appropriate test fix.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
