### PR TITLE
automatically underline links made in the body of blog posts

### DIFF
--- a/blossom/static_dev/css/main.css
+++ b/blossom/static_dev/css/main.css
@@ -66,6 +66,10 @@ a {
     color: black
 }
 
+.underline-links a {
+    text-decoration: underline;
+}
+
 .content {
     margin-top: 1em;
 }

--- a/blossom/templates/website/index.html
+++ b/blossom/templates/website/index.html
@@ -13,11 +13,13 @@
     {% endif %}
     {% for p in posts %}
         <p>
-        <h1><a href="{% get_absolute_uri p%}">{{ p.title }}</a></h1>
+        <h1><a href="{% get_absolute_uri p %}">{{ p.title }}</a></h1>
         </p>
-        <p>
-            {{ p.body|safe }}
-        </p>
+        <div class="underline-links">
+            <p>
+                {{ p.body|safe }}
+            </p>
+        </div>
         <hr>
     {% endfor %}
     <div class="text-center">


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Rather than dealing with manually remembering to mark links as underlined, this adds a CSS tweak so that it happens automatically.
