### PR TITLE
Underline links on detail page

### DIFF
--- a/blossom/static_dev/css/main.css
+++ b/blossom/static_dev/css/main.css
@@ -66,6 +66,10 @@ a {
     color: black
 }
 
+.underline-links a {
+    text-decoration: underline;
+}
+
 .content {
     margin-top: 1em;
 }

--- a/blossom/templates/website/index.html
+++ b/blossom/templates/website/index.html
@@ -13,11 +13,13 @@
     {% endif %}
     {% for p in posts %}
         <p>
-        <h1><a href="{% get_absolute_uri p%}">{{ p.title }}</a></h1>
+        <h1><a href="{% get_absolute_uri p %}">{{ p.title }}</a></h1>
         </p>
-        <p>
-            {{ p.body|safe }}
-        </p>
+        <div class="underline-links">
+            <p>
+                {{ p.body|safe }}
+            </p>
+        </div>
         <hr>
     {% endfor %}
     <div class="text-center">

--- a/blossom/templates/website/post_detail.html
+++ b/blossom/templates/website/post_detail.html
@@ -7,7 +7,9 @@
     <p>
     <h1>{{ post.title }}</h1>
     </p>
-    <p>
-        {{ post.body|safe }}
-    </p>
+    <div class="underline-links">
+        <p>
+            {{ post.body|safe }}
+        </p>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Adds automatic underlining of links to the post detail page.
