### PR TITLE
Tell Bugsnag what version of Blossom is running

### DIFF
--- a/blossom/__init__.py
+++ b/blossom/__init__.py
@@ -1,0 +1,14 @@
+"""Metadata about Blossom. Nothing to see here."""
+
+import os
+
+import toml
+
+try:
+    with open(
+        os.path.join(os.path.dirname(__file__), "..", "pyproject.toml"), "r"
+    ) as f:
+        __version__ = toml.load(f)["tool"]["poetry"]["version"]
+except OSError:
+    __version__ = "unknown"
+    pass

--- a/blossom/settings/base.py
+++ b/blossom/settings/base.py
@@ -13,8 +13,11 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import logging
 import os
 
+import bugsnag
 import dotenv
 from django.urls import reverse_lazy
+
+from blossom import __version__
 
 dotenv.load_dotenv()
 logger = logging.getLogger(__name__)
@@ -253,3 +256,5 @@ if DATABASES["default"].get("PASSWORD") == default_db_password:
 
 if OCR_API_KEY == "helloworld":
     settings_err("Using default OCR API key, not ours!")
+
+bugsnag.configure(app_version=__version__)


### PR DESCRIPTION
## Description:

By reading from the `pyproject.toml`, we can tell the version string. Even if it doesn't exist, it fails gracefully with a version string of `unknown`.

Given our deployment strategy preserves `pyproject.toml` next to the source code, this should be an okay assumption to make.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [x] Wiki Documentation (if applicable)
