### PR TITLE
[RFC] Exempt the API from CSRF protections

### DIFF
--- a/api/views/misc.py
+++ b/api/views/misc.py
@@ -1,6 +1,7 @@
 """Views that don't fit in any of the other view files."""
 from typing import Dict
 
+from django.views.decorators.csrf import csrf_exempt
 from drf_yasg.openapi import Response as DocResponse
 from drf_yasg.openapi import Schema
 from drf_yasg.utils import swagger_auto_schema
@@ -44,6 +45,7 @@ class SummaryView(APIView):
 
     permission_classes = (AdminApiKeyCustomCheck,)
 
+    @csrf_exempt
     @swagger_auto_schema(
         responses={
             200: DocResponse(
@@ -69,6 +71,7 @@ class PingView(APIView):
 
     permission_classes = (AllowAny,)
 
+    @csrf_exempt
     @swagger_auto_schema(
         responses={
             200: DocResponse(

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -8,6 +8,7 @@ from django.db.models.functions import Length
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.openapi import Parameter
 from drf_yasg.openapi import Response as DocResponse
@@ -55,6 +56,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         "redis_id",
     ]
 
+    @csrf_exempt
     @swagger_auto_schema(
         manual_parameters=[
             Parameter("ctq", "query", type="boolean"),
@@ -99,6 +101,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         )
         return Response(self.get_serializer(queryset[:100], many=True).data)
 
+    @csrf_exempt
     @swagger_auto_schema(
         manual_parameters=[Parameter("hours", "query", type="integer")],
         required=["source"],
@@ -136,6 +139,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         )
         return Response(self.get_serializer(queryset[:100], many=True).data)
 
+    @csrf_exempt
     @swagger_auto_schema(
         responses={200: DocResponse("Successful operation", schema=serializer_class)},
         required=["source"],
@@ -161,6 +165,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         )
         return Response(data=self.get_serializer(queryset[:100], many=True).data)
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=Schema(
             type="object", properties={"username": Schema(type="string")}
@@ -206,6 +211,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             data=self.serializer_class(submission, context={"request": request}).data,
         )
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=Schema(
             type="object", properties={"username": Schema(type="string")}
@@ -332,6 +338,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
                 ),
             )
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=Schema(
             type="object",
@@ -408,6 +415,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             data=self.serializer_class(submission, context={"request": request}).data,
         )
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=Schema(
             type="object",
@@ -480,6 +488,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             else:
                 return default
 
+    @csrf_exempt
     @swagger_auto_schema(
         responses={
             200: DocResponse("Successful operation", schema=serializer_class),
@@ -527,6 +536,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             data=self.get_serializer(queryset[:return_limit], many=True).data
         )
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=Schema(
             type="object",
@@ -570,6 +580,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
 
         return Response(status=status.HTTP_200_OK, data={"total_yeeted": yeeted})
 
+    @csrf_exempt
     @action(detail=False, methods=["post"])
     def bulkcheck(self, request: Request) -> Response:
         """Start with of a list of IDs, then return which ones are new to us."""

--- a/api/views/transcription.py
+++ b/api/views/transcription.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.openapi import Parameter
 from drf_yasg.openapi import Response as DocResponse
@@ -38,6 +39,7 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
         "removed_from_reddit",
     ]
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=Schema(
             type="object",
@@ -131,6 +133,7 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+    @csrf_exempt
     @swagger_auto_schema(
         manual_parameters=[Parameter("submission_id", "query", type="string")],
         responses={400: 'Query parameter "submission_id" not present'},
@@ -156,6 +159,7 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
             ).data
         )
 
+    @csrf_exempt
     @swagger_auto_schema(
         responses={
             200: DocResponse(

--- a/api/views/volunteer.py
+++ b/api/views/volunteer.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.openapi import Parameter
 from drf_yasg.openapi import Response as DocResponse
@@ -40,6 +41,7 @@ class VolunteerViewSet(viewsets.ModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["id", "username", "is_volunteer", "accepted_coc", "blacklisted"]
 
+    @csrf_exempt
     @swagger_auto_schema(
         manual_parameters=[Parameter("username", "query", type="string")],
         responses={
@@ -54,6 +56,7 @@ class VolunteerViewSet(viewsets.ModelViewSet):
         user = get_object_or_404(BlossomUser, username=username, is_volunteer=True)
         return Response(self.serializer_class(user).data)
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=no_body, responses={404: "No volunteer with the specified ID."}
     )
@@ -79,6 +82,7 @@ class VolunteerViewSet(viewsets.ModelViewSet):
         )
         return Response(self.serializer_class(user).data)
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=Schema(
             type="object", properties={"username": Schema(type="string")}
@@ -104,6 +108,7 @@ class VolunteerViewSet(viewsets.ModelViewSet):
             self.serializer_class(user).data, status=status.HTTP_201_CREATED
         )
 
+    @csrf_exempt
     @swagger_auto_schema(
         request_body=no_body,
         responses={


### PR DESCRIPTION
## Description:

Currently the bots call out to a non-existent API endpoint to harvest a CSRF token, then call to the appropriate API. That results in lots of errors generated. I'm arguing here that it isn't necessary to protect the API like that.

Given CSRF protection is an anti-bot measure, an API by nature is intended for bots, and we are already authenticating every request with an API token, applying exemptions to all authenticated API endpoints seems prudent.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [x] Wiki Documentation (if applicable)
