### PR TITLE
Emulates blossom deployment with docker-compose

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,4 @@ import-order-style = pycharm
 max-complexity = 10
 max-line-length = 90
 use-varnames-strict-mode = true
-exclude =  .git,__pycache__,build,dist,.venv,bootstrap/*,*/migrations/
+exclude =  .git,__pycache__,build,dist,.venv,bootstrap/*,*/migrations/,docker/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A Django app that serves our website, payment portal for donations, engineering 
 
 ## Local development
 
+> For a quick and dirty method of testing blossom locally, run `docker-compose up -d` and point your browser to <http://localhost:8080/>
+
 Create a file under the top level `blossom` folder called `local_settings.py`. Populate it with the following:
 
 ```python

--- a/blossom/settings/base.py
+++ b/blossom/settings/base.py
@@ -115,11 +115,11 @@ default_db_password = "Pink fluffy unicorns dancing on rainbows"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "blossom",
-        "USER": "blossom_app",
+        "NAME": os.getenv("BLOSSOM_DB_DATABASE", "blossom"),
+        "USER": os.getenv("BLOSSOM_DB_USERNAME", "blossom_app"),
         "PASSWORD": os.getenv("BLOSSOM_DB_PASSWORD", default_db_password),
-        "HOST": "localhost",
-        "PORT": "",
+        "HOST": os.getenv("BLOSSOM_DB_HOST", "localhost"),
+        "PORT": os.getenv("BLOSSOM_DB_PORT", ""),
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   db:
     image: postgres:11.5-alpine
     environment:
-      POSTGRES_DB: 'mydb'
-      POSTGRES_PASSWORD: 'hunter2'
-      POSTGRES_USER: 'roto_rooter'
+      POSTGRES_DB: 'local_blossom'
+      POSTGRES_PASSWORD: 'this-is-not-prod-so-why-do-we-care'
+      POSTGRES_USER: 'blossom_is_the_best'
     volumes:
       - ./docker/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     ports:
@@ -22,9 +22,9 @@ services:
       ENVIRONMENT: local
       PORT: '8000'
       BLOSSOM_SECRET_KEY: 'imhenrytheeigthiam.henrytheeigthiamiam.igotmarriedtothewidownextdoor.shesbeenmarriedseventimesbefore'
-      BLOSSOM_DB_DATABASE: 'mydb'
-      BLOSSOM_DB_USERNAME: 'roto_rooter'
-      BLOSSOM_DB_PASSWORD: 'hunter2'
+      BLOSSOM_DB_DATABASE: 'local_blossom'
+      BLOSSOM_DB_USERNAME: 'blossom_is_the_best'
+      BLOSSOM_DB_PASSWORD: 'this-is-not-prod-so-why-do-we-care'
       BLOSSOM_DB_HOST: db  # Funky DNS stuff with docker-compose. See above service.
       BLOSSOM_DB_PORT: '5432'
       DJANGO_LOG_LEVEL: INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+---
+version: '3'
+services:
+  db:
+    image: postgres:11.5-alpine
+    environment:
+      POSTGRES_DB: 'mydb'
+      POSTGRES_PASSWORD: 'hunter2'
+      POSTGRES_USER: 'roto_rooter'
+    volumes:
+      - ./docker/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    ports:
+      - 5432:5432
+
+  blossom:
+    depends_on:
+      - db
+    build:
+      context: .
+      dockerfile: ./docker/blossom.Dockerfile
+    environment:
+      ENVIRONMENT: local
+      PORT: '8000'
+      BLOSSOM_SECRET_KEY: 'imhenrytheeigthiam.henrytheeigthiamiam.igotmarriedtothewidownextdoor.shesbeenmarriedseventimesbefore'
+      BLOSSOM_DB_DATABASE: 'mydb'
+      BLOSSOM_DB_USERNAME: 'roto_rooter'
+      BLOSSOM_DB_PASSWORD: 'hunter2'
+      BLOSSOM_DB_HOST: db  # Funky DNS stuff with docker-compose. See above service.
+      BLOSSOM_DB_PORT: '5432'
+      DJANGO_LOG_LEVEL: INFO
+    volumes:
+      - static:/app/blossom/static
+      - ./blossom/settings:/app/blossom/settings:ro
+      - ./docker/local_settings.py:/app/blossom/settings/local.py:ro
+
+  http:
+    depends_on:
+      - blossom  # Because DNS needs to be there or this container fails
+    image: nginx:alpine
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+      - static:/data/static:ro
+    ports:
+      - 8080:80
+
+volumes:
+  static:

--- a/docker/blossom-entrypoint.sh
+++ b/docker/blossom-entrypoint.sh
@@ -6,6 +6,8 @@ if [ "$1" = "runserver" ]; then
   python manage.py bootstrap_site
   python manage.py collectstatic --noinput -v 0
 
-  gunicorn -c ./blossom/instrumentation.py --access-logfile - --workers 3 --bind "0.0.0.0:${PORT}" blossom.wsgi:application
+  exec gunicorn -c ./blossom/instrumentation.py --access-logfile - --workers 3 --bind "0.0.0.0:${PORT}" blossom.wsgi:application
   # python manage.py runserver "0.0.0.0:${PORT}"
+else
+  exec "$@"
 fi

--- a/docker/blossom-entrypoint.sh
+++ b/docker/blossom-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "runserver" ]; then
+  python manage.py migrate
+  python manage.py bootstrap_site
+  python manage.py collectstatic --noinput -v 0
+
+  gunicorn -c ./blossom/instrumentation.py --access-logfile - --workers 3 --bind "0.0.0.0:${PORT}" blossom.wsgi:application
+  # python manage.py runserver "0.0.0.0:${PORT}"
+fi

--- a/docker/blossom.Dockerfile
+++ b/docker/blossom.Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3-slim as base
+
+# Ensures output from python is sent straight to the terminal without buffering it first
+ENV PYTHONUNBUFFERED 1
+
+# It's a container and we know pip should be upgraded. Shaddup
+ENV PIP_DISABLE_PIP_VERSION_CHECK 1
+
+# hadolint ignore=DL3013,DL3042
+RUN pip install --upgrade pip
+
+WORKDIR /app
+
+FROM base as builder
+
+# hadolint ignore=DL3013,DL3042
+RUN pip install poetry
+
+COPY ./pyproject.toml /app
+COPY ./poetry.lock /app
+
+RUN poetry export --format=requirements.txt --output=requirements.txt
+
+FROM base as runtime
+
+ENV PORT 8080
+EXPOSE 8080
+
+COPY . /app
+
+COPY ./docker/blossom-entrypoint.sh /docker-entrypoint.sh
+
+COPY --from=builder /app/requirements.txt /app/requirements.txt
+
+# hadolint ignore=DL3013,DL3042
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["bash", "/docker-entrypoint.sh"]
+CMD ["runserver"]

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,0 +1,4 @@
+--
+-- Here's where you would write some initial SQL prior to
+-- running DB migrations. Perhaps activating a pg extension?
+--

--- a/docker/local_settings.py
+++ b/docker/local_settings.py
@@ -1,0 +1,9 @@
+# noinspection PyUnresolvedReferences
+from blossom.settings.base import *
+
+ENVIRONMENT = "local"
+
+DEBUG = True
+ENABLE_SLACK = False
+
+ALLOWED_HOSTS = ["*"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,53 @@
+# upstream blossom {
+#     server blossom resolve;
+# }
+
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost blossom.localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location /static/ {
+        root   /data;
+        index  index.html index.htm;
+    }
+
+    location / {
+        proxy_pass http://blossom:8000;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+


### PR DESCRIPTION
## Description:

For closer emulation to what is running on prod, here's a `docker-compose` manifest and associated files for running blossom entirely locally using Docker and `docker-compose` as an orchestrator.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [x] Wiki Documentation (if applicable)