### PR TITLE
show date on most posts and clean up display of admin panel

### DIFF
--- a/blossom/templates/website/admin.html
+++ b/blossom/templates/website/admin.html
@@ -27,7 +27,7 @@
             <tr>
                 <th scope="row"><a href="{{ p.get_absolute_url }}edit">{{ p.id }}</a></th>
                 <td><a href="{{ p.get_absolute_url }}edit">{{ p.title }}</a></td>
-                <td>{{ p.published }}</td>
+                <td>{% if p.published %}✓{% else %}✗{% endif %}</td>
                 <td>{{ p.date }}</td>
             </tr>
         {% endfor %}

--- a/blossom/templates/website/index.html
+++ b/blossom/templates/website/index.html
@@ -18,7 +18,7 @@
         </p>
         <div class="underline-links">
             <p>
-                {{ p.body|safe }}
+                {{ p.body|safe|truncatewords:80 }}
             </p>
         </div>
         <hr>

--- a/blossom/templates/website/index.html
+++ b/blossom/templates/website/index.html
@@ -14,6 +14,7 @@
     {% for p in posts %}
         <p>
         <h1><a href="{% get_absolute_uri p %}">{{ p.title }}</a></h1>
+        <span class="text-muted">Published {{ p.date }}</span>
         </p>
         <div class="underline-links">
             <p>

--- a/blossom/templates/website/post_detail.html
+++ b/blossom/templates/website/post_detail.html
@@ -6,6 +6,10 @@
     {% endif %}
     <p>
     <h1>{{ post.title }}</h1>
+    {% if not post.standalone_section %}
+        {# so that we don't show the date on things in the header bar, like the donation page #}
+        <span class="text-muted">Published {{ post.date }}</span>
+    {% endif %}
     </p>
     <div class="underline-links">
         <p>


### PR DESCRIPTION
Relevant issue: N/a

## Description:

Adds the date to posts that aren't in the menu bar (like the donation page / about page) and also trades out the boolean field in the admin panel for ✓ / ✗ instead of True / False.

## Screenshots:

Post detail view:
![image](https://user-images.githubusercontent.com/5179553/121633393-b81c7800-ca50-11eb-8b5e-b40174c24e46.png)

Index view:
![image](https://user-images.githubusercontent.com/5179553/121633700-498bea00-ca51-11eb-9e39-3e4591b9c085.png)

Note that header bar posts are unaffected:

![image](https://user-images.githubusercontent.com/5179553/121633748-60cad780-ca51-11eb-98f9-501bad562095.png)

Admin panel change:

![image](https://user-images.githubusercontent.com/5179553/121633784-750ed480-ca51-11eb-9178-f88176cacd75.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
