### PR TITLE
Add first_active field to BlossomUser model

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -26,7 +26,7 @@ class VolunteerSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "username",
             "gamma",
-            "date_joined",
+            "first_active",
             "last_login",
             "last_update_time",
             "accepted_coc",

--- a/authentication/models.py
+++ b/authentication/models.py
@@ -1,4 +1,7 @@
 """Models used within the Authentication application."""
+import datetime
+from typing import Optional
+
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.utils import timezone
@@ -57,6 +60,23 @@ class BlossomUser(AbstractUser):
         if self.blacklisted:
             return 0  # see https://github.com/GrafeasGroup/blossom/issues/15
         return Submission.objects.filter(completed_by=self).count()
+
+    @property
+    def first_active(self) -> Optional[datetime.datetime]:
+        """
+        Return the date when the user was first active.
+
+        Usually, this is the date of their first transcription.
+
+        :return: the date when the user was first active or None if they haven't
+        transcribed yet.
+        """
+        return (
+            Submission.objects.filter(claimed_by=self)
+            .order_by("claim_time")
+            .first()
+            .claim_time
+        )
 
     def __str__(self) -> str:
         return self.username

--- a/authentication/models.py
+++ b/authentication/models.py
@@ -71,12 +71,10 @@ class BlossomUser(AbstractUser):
         :return: the date when the user was first active or None if they haven't
         transcribed yet.
         """
-        return (
-            Submission.objects.filter(claimed_by=self)
-            .order_by("claim_time")
-            .first()
-            .claim_time
+        first_claim = (
+            Submission.objects.filter(claimed_by=self).order_by("claim_time").first()
         )
+        return None if first_claim is None else first_claim.claim_time
 
     def __str__(self) -> str:
         return self.username


### PR DESCRIPTION
Relevant issue: Closes #141.

## Description:

The Slack `info` command used the `date_joined` field of  `BlossomUser`. However, this is actually never assigned anywhere, so it always returned the current time.
This adds a separate `first_active` field which returns the time of the first claimed transcription. This is then used instead of the `date_joined` field for the `info` command.

## Testing Instructions:

Locally setup the Blossom Testing App. Then you can test the `info <username>` command and verify that the `date_joined` field has been replaced by `first_active` and returns a sensible value.

Because I didn't manage to set up Slack locally yet, it would be nice if someone could verify this for me.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
