### PR TITLE
add content_url to the serialized fields

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -62,6 +62,7 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
             "source",
             "url",
             "tor_url",
+            "content_url",
             "has_ocr_transcription",
             "transcription_set",
             "archived",


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Makes the API return `content_url` along with the other fields.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
