### PR TITLE
Add Plausible

### DIFF
--- a/blossom/templates/website/partials/base.partial
+++ b/blossom/templates/website/partials/base.partial
@@ -29,6 +29,7 @@
           integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <link href="{% static "js/prism_js/prism-tomorrow-night.css" %}" rel="stylesheet">
     <link rel="stylesheet" href="{% static "css/main.css" %}">
+    <script defer data-domain="grafeas.org" src="https://plausible.io/js/plausible.js"></script>
 
     <title>Grafeas Group, Ltd.</title>
 </head>


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This adds Plausible support for the website. Plausible is an ethical metrics company that I've used for my own sites for a year and I have an extra slot to add in for Grafeas, so why not? Here's the dashboard for my filament website -- the metrics collected are exactly the same and we can make the dashboard public for all to see. https://plausible.io/filamentcolors.xyz

## Checklist:

- [x] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
