### PR TITLE
Change url routes to remove pk

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -31,7 +31,7 @@ class Post(models.Model):
 
     def get_absolute_url(self) -> str:
         """Return the full url of a given post."""
-        kwargs = {"pk": self.id, "slug": self.slug}
+        kwargs = {"slug": self.slug}
         return reverse("post_detail", kwargs=kwargs)
 
     def save(self, *args: object, **kwargs: object) -> None:

--- a/website/urls.py
+++ b/website/urls.py
@@ -6,12 +6,19 @@ from website.helpers import grafeas_staff_required
 
 urlpatterns = [
     path("", views.index, name="homepage"),
-    path("posts/<int:pk>-<str:slug>/", views.PostDetail.as_view(), name="post_detail"),
+    # compatibility layer to allow old style URLs to resolve to slug-only.
+    # Must be above regular version.
+    path(
+        "posts/<int:pk>-<str:slug>/",
+        views.post_view_redirect,
+        name="post_detail_redirect",
+    ),
+    path("posts/<str:slug>/", views.PostDetail.as_view(), name="post_detail"),
     path(
         "newpost", grafeas_staff_required(views.PostAdd.as_view()), name="post_create"
     ),
     path(
-        "posts/<int:pk>-<str:slug>/edit/",
+        "posts/<str:slug>/edit/",
         grafeas_staff_required(views.PostUpdate.as_view()),
         name="post_update",
     ),

--- a/website/views.py
+++ b/website/views.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import HttpResponseRedirect, redirect, render
+from django.shortcuts import HttpResponseRedirect, redirect, render, reverse
 from django.views.generic import DetailView, TemplateView, UpdateView
 
 from authentication.mixins import GrafeasStaffRequired
@@ -29,7 +29,6 @@ class PostDetail(DetailView):
     """Render a specific post on the website."""
 
     model = Post
-    query_pk_and_slug = True
     template_name = "website/post_detail.html"
 
     def get_context_data(self, **kwargs: object) -> Dict:
@@ -39,11 +38,15 @@ class PostDetail(DetailView):
         return context
 
 
+def post_view_redirect(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
+    """Compatibility layer to take in old-style PK+slug urls and return slug only."""
+    return HttpResponseRedirect(reverse("post_detail", kwargs={"slug": slug}))
+
+
 class PostUpdate(GrafeasStaffRequired, UpdateView):
     """Modify a post on the website."""
 
     model = Post
-    query_pk_and_slug = True
     fields = [
         "title",
         "body",


### PR DESCRIPTION
Relevant issue: N/A

## Description:

When I set up the routes for the posts on the website, I used pk+slug (`1-our-story`) so that we could have multiple posts with the same name and still tell them apart. That's a great idea as long as the primary key doesn't change, and for some reason it is and the PK of our donations page keeps changing and invalidating its own URL. This PR:

* swaps over to slug only routes
* provides a compatibility redirect layer for the routes we've already publicized -- can be removed after we forget why we added it

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
