### PR TITLE
Adds facebook and twitter cards to pages

### DIFF
--- a/blossom/templates/website/partials/base.partial
+++ b/blossom/templates/website/partials/base.partial
@@ -31,6 +31,31 @@
     <link rel="stylesheet" href="{% static "css/main.css" %}">
     <script defer data-domain="grafeas.org" src="https://plausible.io/js/plausible.js"></script>
 
+    {# twitter #}
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:creator" content="@grafeas">
+    <meta name="twitter:site" content="@grafeas">
+    <meta name="twitter:image:src" content="https://grafeas.org/static/images/logo.svg">
+    <meta name="twitter:image:width" content="280">
+    <meta name="twitter:image:height" content="150">
+    <meta name="twitter:image:alt"
+          content="The logo of the Grafeas Group. It is made of two capital Gs, one upright and the other mirrored and upside-down, and connected by the vertical 'bar' of the two Gs. the letters are centered over the outline of a quill pen.">
+    {% block socialmediatwitter %}
+        <meta name="twitter:title"
+              content="The Grafeas Group - Digital Scribes for Accessibility!">
+        <meta name="twitter:description"
+              content="The Grafeas Group is a 501(c)(3) working on increasing accessibility on the internet though crowdsourcing and gamification.">
+    {% endblock %}
+
+    {# facebook #}
+    <meta property="og:image" content="https://grafeas.org/static/images/logo.svg">
+    <meta name="og:image:width" content="280">
+    <meta name="og:image:height" content="150">
+    {% block socialmediafacebook %}
+        <meta property="og:title"
+              content="The Grafeas Group - Digital Scribes for Accessibility!">
+    {% endblock %}
+
     <title>Grafeas Group, Ltd.</title>
 </head>
 

--- a/blossom/templates/website/post_detail.html
+++ b/blossom/templates/website/post_detail.html
@@ -1,5 +1,17 @@
 {% extends 'website/partials/base.partial' %}
 
+{% block socialmediatwitter %}
+    <meta name="twitter:title"
+          content="Grafeas Group - {{ post.title }}">
+    <meta name="twitter:description"
+          content="{{ post.body|safe|truncatechars:200 }}">
+{% endblock %}
+
+{% block socialmediafacebook %}
+    <meta property="og:title"
+          content="Grafeas Group - {{ post.title }}">
+{% endblock %}
+
 {% block content %}
     {% if request.user.is_authenticated %}
         <a class="btn btn-primary" href="edit/">Edit!</a>


### PR DESCRIPTION
Relevant issue: #151 

## Description:

Adds card support for Twitter and Facebook. Uses the formatting developed for https://filamentcolors.xyz, which will translate nicely to what we need. This PR handles updating the title and body of the card depending on whether we're looking at a main page or a post detail.

## Screenshots:

![image](https://user-images.githubusercontent.com/5179553/121997624-a6044780-cd78-11eb-8ec6-21a625d0e02f.png)

## Checklist:

- [x] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
