### PR TITLE
Add custom default pagination class

### DIFF
--- a/api/pagination.py
+++ b/api/pagination.py
@@ -1,0 +1,9 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class StandardResultsSetPagination(PageNumberPagination):
+    """The standard pagination class to use for the queries."""
+
+    page_size = 25
+    page_size_query_param = "page_size"
+    max_page_size = 500

--- a/blossom/settings/base.py
+++ b/blossom/settings/base.py
@@ -146,8 +146,7 @@ LOGGING = {
 }
 
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    "PAGE_SIZE": 25,
+    "DEFAULT_PAGINATION_CLASS": "api.pagination.StandardResultsSetPagination",
     "DEFAULT_PERMISSION_CLASSES": ("api.authentication.BlossomApiPermission",),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "authentication.backends.BlossomRestFrameworkAuth",


### PR DESCRIPTION
Relevant issue: Closes #156.

## Description:

This changes the default pagination class to a custom one. This allows us to set a `page_size` parameter to control the number of items per page. The current maximum is set to 500, but we might wanna adjust this to our needs.
This change is important for buttercup to reduce the number of API requests and thus the delays.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
