### PR TITLE
Slim down logic for transcribot queue

### DIFF
--- a/api/tests/submissions/test_submission_transcribot_queue.py
+++ b/api/tests/submissions/test_submission_transcribot_queue.py
@@ -20,9 +20,9 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
-        assert len(result.data) == 0  # there are no posts to work on
+        assert len(result["data"]) == 0  # there are no posts to work on
 
         submission = create_submission(source="reddit")
 
@@ -30,20 +30,20 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
         # now there's a submission without a transcribot transcription
-        assert len(result.data) == 0
+        assert len(result["data"]) == 0
         create_transcription(submission, transcribot, original_id=None)
 
         result = client.get(
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
         # now the submission has a transcribot entry
-        assert len(result.data) == 1
+        assert len(result["data"]) == 1
 
     def test_completed_ocr_transcriptions(
         self, client: Client, setup_site: Any
@@ -58,9 +58,9 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
-        assert len(result.data) == 0
+        assert len(result["data"]) == 0
 
         transcription = create_transcription(submission, transcribot, original_id=None)
 
@@ -68,10 +68,10 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
         # now there's a transcription that needs work
-        assert len(result.data) == 1
+        assert len(result["data"]) == 1
 
         # transcribot works on it
         transcription.original_id = "AAA"
@@ -81,10 +81,10 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
         # Queue goes back to 0.
-        assert len(result.data) == 0
+        assert len(result["data"]) == 0
 
     def test_normal_transcriptions_dont_affect_ocr_queue(
         self, client: Client, setup_site: Any
@@ -97,9 +97,9 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
-        assert len(result.data) == 0
+        assert len(result["data"]) == 0
 
         create_transcription(submission, user)
 
@@ -107,10 +107,10 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
         # there should be no change to the OCR queue
-        assert len(result.data) == 0
+        assert len(result["data"]) == 0
 
     def test_transcribot_limit_param(self, client: Client, setup_site: Any) -> None:
         """Verify that adding the `limit` QSP modifies the results."""
@@ -130,18 +130,18 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit&limit=none",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
-        assert len(result.data) == 3
+        assert len(result["data"]) == 3
 
         result = client.get(
             reverse("submission-get-transcribot-queue") + "?source=reddit&limit=1",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
-        assert len(result.data) == 1
-        assert result.json()[0]["id"] == submission1.id
+        assert len(result["data"]) == 1
+        assert result["data"][0]["id"] == submission1.id
 
     def test_verify_no_removed_posts(self, client: Client, setup_site: Any) -> None:
         """Verify that a post removed from the queue is not sent to transcribot."""
@@ -163,9 +163,9 @@ class TestSubmissionTranscribotQueue:
             reverse("submission-get-transcribot-queue") + "?source=reddit&limit=none",
             content_type="application/json",
             **headers,
-        )
+        ).json()
 
-        assert len(result.data) == 2
+        assert len(result["data"]) == 2
 
 
 def test_get_limit() -> None:

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -535,9 +535,6 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             :return_limit
         ]
         return JsonResponse({"data": list(queryset)})
-        # return Response(
-        #     data=self.get_serializer(queryset[:return_limit], many=True).data
-        # )
 
     @swagger_auto_schema(
         request_body=Schema(

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -5,6 +5,7 @@ from typing import Union
 
 from django.conf import settings
 from django.db.models.functions import Length
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -494,7 +495,9 @@ class SubmissionViewSet(viewsets.ModelViewSet):
     )
     @validate_request(query_params={"source"})
     @action(detail=False, methods=["get"])
-    def get_transcribot_queue(self, request: Request, source: str = None) -> Response:
+    def get_transcribot_queue(
+        self, request: Request, source: str = None
+    ) -> JsonResponse:
         """
         Get the submissions that still need to be attempted by transcribot.
 
@@ -528,10 +531,13 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             transcription__original_id__isnull=True,
             removed_from_queue=False,
             cannot_ocr=False,
-        )
-        return Response(
-            data=self.get_serializer(queryset[:return_limit], many=True).data
-        )
+        ).values("id", "tor_url", "transcription__id", "transcription__text")[
+            :return_limit
+        ]
+        return JsonResponse({"data": list(queryset)})
+        # return Response(
+        #     data=self.get_serializer(queryset[:return_limit], many=True).data
+        # )
 
     @swagger_auto_schema(
         request_body=Schema(


### PR DESCRIPTION
Relevant issue: N/A

Matching tor_ocr PR: https://github.com/GrafeasGroup/tor_ocr/pull/40

## Description:

The single most time-intensive database query right now belongs to the transcribot queue query, taking roughly half a second to process and called every two seconds. This PR does two things:

* drastically limits the data that is actually pulled from the database
* bypasses the serializer, which chops off a fair amount of extra processing we don't need

We will not know _how much_ of a difference this makes until this is deployed and we can observe with honeycomb, but my gut reaction is that we should see a significant change.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
