### PR TITLE
Add `/volunteer/heatmap` endpoint

### DIFF
--- a/api/tests/test_volunteers.py
+++ b/api/tests/test_volunteers.py
@@ -1,5 +1,6 @@
 """Tests to validate the behavior of the VolunteerViewSet."""
 import json
+from datetime import datetime
 
 from django.test import Client
 from django.urls import reverse
@@ -273,3 +274,94 @@ class TestVolunteerCoCAcceptance:
         assert result.status_code == status.HTTP_409_CONFLICT
         user.refresh_from_db()
         assert user.accepted_coc is True
+
+
+class TestHeatmap:
+    """Tests to validate that the heatmap data is generated correctly."""
+
+    def test_heatmap_time_slots(self, client: Client) -> None:
+        """Test that the time slots are assigned as expected."""
+        client, headers, user = setup_user_client(
+            client, accepted_coc=True, username="test_user"
+        )
+
+        # Thursday 14 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2020, 7, 16, 14, 3, 55)
+        )
+        # Sunday 15 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2021, 6, 20, 15, 10, 5)
+        )
+        # Wednesday 03 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2021, 6, 23, 3, 16, 30)
+        )
+        # Saturday 21 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2021, 6, 26, 21, 1, 10)
+        )
+
+        result = client.get(
+            reverse("volunteer-heatmap") + "?username=test_user",
+            content_type="application/json",
+            **headers,
+        )
+
+        assert result.status_code == status.HTTP_200_OK
+
+        expected_heatmap = [
+            {"day": 1, "hour": 15, "count": 1},
+            {"day": 4, "hour": 3, "count": 1},
+            {"day": 5, "hour": 14, "count": 1},
+            {"day": 7, "hour": 21, "count": 1},
+        ]
+        heatmap = result.json()
+        assert heatmap == expected_heatmap
+
+    def test_heatmap_aggregation(self, client: Client) -> None:
+        """Test that transcriptions in the same slot are aggregated."""
+        client, headers, user = setup_user_client(
+            client, accepted_coc=True, username="test_user"
+        )
+
+        # Thursday 14 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2020, 7, 16, 14, 3, 55)
+        )
+        # Thursday 14 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2020, 7, 16, 14, 59, 55)
+        )
+        # Sunday 15 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2021, 6, 20, 15, 10, 5)
+        )
+        # Sunday 15 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2021, 6, 20, 15, 42, 10)
+        )
+        # Sunday 16 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2021, 6, 20, 16, 5, 5)
+        )
+        # Thursday 14 h
+        create_transcription(
+            create_submission(), user, create_time=datetime(2021, 6, 24, 14, 30, 30)
+        )
+
+        result = client.get(
+            reverse("volunteer-heatmap") + "?username=test_user",
+            content_type="application/json",
+            **headers,
+        )
+
+        assert result.status_code == status.HTTP_200_OK
+
+        expected_heatmap = [
+            {"day": 1, "hour": 15, "count": 2},
+            {"day": 1, "hour": 16, "count": 1},
+            {"day": 5, "hour": 14, "count": 3},
+        ]
+        heatmap = result.json()
+        assert heatmap == expected_heatmap

--- a/api/tests/test_volunteers.py
+++ b/api/tests/test_volunteers.py
@@ -311,10 +311,14 @@ class TestHeatmap:
         assert result.status_code == status.HTTP_200_OK
 
         expected_heatmap = [
-            {"day": 1, "hour": 15, "count": 1},
-            {"day": 4, "hour": 3, "count": 1},
-            {"day": 5, "hour": 14, "count": 1},
-            {"day": 7, "hour": 21, "count": 1},
+            # Wednesday 03 h
+            {"day": 3, "hour": 3, "count": 1},
+            # Thursday 14 h
+            {"day": 4, "hour": 14, "count": 1},
+            # Saturday 21 h
+            {"day": 6, "hour": 21, "count": 1},
+            # Sunday 15 h
+            {"day": 7, "hour": 15, "count": 1},
         ]
         heatmap = result.json()
         assert heatmap == expected_heatmap
@@ -359,9 +363,12 @@ class TestHeatmap:
         assert result.status_code == status.HTTP_200_OK
 
         expected_heatmap = [
-            {"day": 1, "hour": 15, "count": 2},
-            {"day": 1, "hour": 16, "count": 1},
-            {"day": 5, "hour": 14, "count": 3},
+            # Thursday 14 h
+            {"day": 4, "hour": 14, "count": 3},
+            # Sunday 15 h
+            {"day": 7, "hour": 15, "count": 2},
+            # Sunday 16 h
+            {"day": 7, "hour": 16, "count": 1},
         ]
         heatmap = result.json()
         assert heatmap == expected_heatmap

--- a/api/views/volunteer.py
+++ b/api/views/volunteer.py
@@ -1,6 +1,8 @@
 """Views that specifically relate to volunteers."""
 import uuid
 
+from django.db.models import Count
+from django.db.models.functions import ExtractHour, ExtractWeekDay
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -55,6 +57,44 @@ class VolunteerViewSet(viewsets.ModelViewSet):
         """Get information on the volunteer with the provided username."""
         user = get_object_or_404(BlossomUser, username=username, is_volunteer=True)
         return Response(self.serializer_class(user).data)
+
+    @csrf_exempt
+    @swagger_auto_schema(
+        manual_parameters=[Parameter("username", "query", type="string")],
+        responses={
+            400: 'No "username" as a query parameter.',
+            404: "No volunteer with the specified username.",
+        },
+    )
+    @action(detail=False, methods=["get"])
+    @validate_request(query_params={"username"})
+    def heatmap(self, request: Request, username: str = None) -> Response:
+        """Get the data to generate a heatmap for the volunteer.
+
+        This includes one entry for every weekday and every hour containing the
+        number of transcriptions made in that time slot.
+        For example, there will be an entry for Sundays at 13:00 UTC, counting
+        how many transcriptions the volunteer made in that time.
+
+        The week days are numbered Sunday=1 through Saturday=7 (blame Django for that).
+        """
+        user = get_object_or_404(BlossomUser, username=username, is_volunteer=True)
+        heatmap = (
+            # Get the transcriptions made by the user
+            Transcription.objects.filter(author=user)
+            # Extract the day of the week and the hour the transcription was made in
+            .annotate(
+                day=ExtractWeekDay("create_time"), hour=ExtractHour("create_time")
+            )
+            # Group by the day and hour
+            .values("day", "hour")
+            # Count the transcription made in each time slot
+            .annotate(count=Count("id"))
+            # Return the values
+            .values("day", "hour", "count")
+        )
+
+        return Response(heatmap)
 
     @csrf_exempt
     @swagger_auto_schema(

--- a/api/views/volunteer.py
+++ b/api/views/volunteer.py
@@ -2,7 +2,7 @@
 import uuid
 
 from django.db.models import Count
-from django.db.models.functions import ExtractHour, ExtractWeekDay
+from django.db.models.functions import ExtractHour, ExtractIsoWeekDay
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -76,7 +76,7 @@ class VolunteerViewSet(viewsets.ModelViewSet):
         For example, there will be an entry for Sundays at 13:00 UTC, counting
         how many transcriptions the volunteer made in that time.
 
-        The week days are numbered Sunday=1 through Saturday=7 (blame Django for that).
+        The week days are numbered Monday=1 through Sunday=7.
         """
         user = get_object_or_404(BlossomUser, username=username, is_volunteer=True)
         heatmap = (
@@ -84,7 +84,7 @@ class VolunteerViewSet(viewsets.ModelViewSet):
             Transcription.objects.filter(author=user)
             # Extract the day of the week and the hour the transcription was made in
             .annotate(
-                day=ExtractWeekDay("create_time"), hour=ExtractHour("create_time")
+                day=ExtractIsoWeekDay("create_time"), hour=ExtractHour("create_time")
             )
             # Group by the day and hour
             .values("day", "hour")

--- a/api/views/volunteer.py
+++ b/api/views/volunteer.py
@@ -92,6 +92,8 @@ class VolunteerViewSet(viewsets.ModelViewSet):
             .annotate(count=Count("id"))
             # Return the values
             .values("day", "hour", "count")
+            # Order by day first, then hour
+            .order_by("day", "hour")
         )
 
         return Response(heatmap)


### PR DESCRIPTION
Relevant issue: GrafeasGroup/buttercup#29, Closes #166

## Description:

Adds a `/volunteer/heatmap` endpoint to get the data necessary to create a heatmap like this:
![Heatmap as generated by tor-user-stats](https://user-images.githubusercontent.com/13908946/123093799-639fd200-d42c-11eb-987f-0c1e41a7b0a4.png)

It counts how many transcriptions a user has done in each hour of each day of the week.

For the response, unfortunately Sunday is 1 and Saturday 7, blame Django for that.
![Sample response displayed on Swagger](https://user-images.githubusercontent.com/13908946/123093996-a792d700-d42c-11eb-9a2a-7c49f723e7c4.png)


## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
