### PR TITLE
Add time-based filtering for Submissions

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,5 +2,5 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = beeline,better_exceptions,blossom_wrapper,bugsnag,django,django_filters,dotenv,dpath,drf_yasg,mimesis,praw,prawcore,psaw,pytest,pytest_django,pytz,requests,rest_framework,rest_framework_api_key,slack,social_core,stripe,toml
+known_third_party = beeline,better_exceptions,blossom_wrapper,bugsnag,dateparser,django,django_filters,dotenv,dpath,drf_yasg,mimesis,praw,prawcore,psaw,pytest,pytest_django,pytz,requests,rest_framework,rest_framework_api_key,slack,social_core,stripe,toml
 skip=venv,.venv,env,migrations

--- a/api/filters.py
+++ b/api/filters.py
@@ -1,0 +1,32 @@
+import dateparser
+from django.db.models.query import QuerySet
+from django.db.models.query_utils import Q
+from django.utils import timezone
+from rest_framework.filters import BaseFilterBackend
+from rest_framework.request import Request
+from rest_framework.views import View
+
+
+class TimeFilter(BaseFilterBackend):
+    def filter_queryset(
+        self, request: Request, queryset: QuerySet, view: View
+    ) -> QuerySet:
+        """Attempt to filter a request by time descriptors if available."""
+        filters = Q()
+        if from_time := request.query_params.get("from"):
+            try:
+                filters = filters & Q(
+                    complete_time__gt=timezone.make_aware(dateparser.parse(from_time))
+                )
+            except AttributeError:
+                pass
+
+        if until_time := request.query_params.get("until"):
+            try:
+                filters = filters & Q(
+                    complete_time__lt=timezone.make_aware(dateparser.parse(until_time))
+                )
+            except AttributeError:
+                pass
+
+        return queryset.filter(filters)

--- a/api/tests/submissions/test_submission_get.py
+++ b/api/tests/submissions/test_submission_get.py
@@ -1,5 +1,8 @@
+import datetime
+
 from django.test import Client
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 
 from api.models import Source
@@ -97,3 +100,84 @@ class TestSubmissionGet:
         assert len(result.json()["results"]) == 1
         assert "AAA" in result.json()["results"][0]["source"]  # it will be a full link
         assert result.json()["results"][0]["id"] == 1
+
+    def test_list_with_time_filters(self, client: Client) -> None:
+        """Verify that listing submissions using time filters works correctly."""
+        client, headers, _ = setup_user_client(client)
+
+        create_submission(
+            complete_time=timezone.make_aware(datetime.datetime(2021, 1, 1))
+        )
+        create_submission(
+            complete_time=timezone.make_aware(datetime.datetime(2021, 1, 2))
+        )
+        create_submission(
+            complete_time=timezone.make_aware(datetime.datetime(2021, 1, 3))
+        )
+        create_submission(
+            complete_time=timezone.make_aware(datetime.datetime(2021, 1, 4))
+        )
+
+        result = client.get(
+            reverse("submission-list") + "?from=2021-01-02,1pm",
+            content_type="application/json",
+            **headers,
+        )
+        assert result.status_code == status.HTTP_200_OK
+        assert len(result.json()["results"]) == 2
+
+        result = client.get(
+            reverse("submission-list") + "?from=2021-01-03",
+            content_type="application/json",
+            **headers,
+        )
+        assert len(result.json()["results"]) == 1
+
+        result = client.get(
+            reverse("submission-list") + "?from=2020-12-31&until=2021-01-05",
+            content_type="application/json",
+            **headers,
+        )
+        assert len(result.json()["results"]) == 4
+
+    def test_list_with_advanced_time_filters(self, client: Client) -> None:
+        """Verify that listing items with English time filters works properly."""
+        client, headers, _ = setup_user_client(client)
+        today = timezone.now()
+
+        create_submission(complete_time=today - timezone.timedelta(hours=6))
+        create_submission(complete_time=today - timezone.timedelta(days=1))
+        create_submission(complete_time=today - timezone.timedelta(days=2))
+        create_submission(complete_time=today - timezone.timedelta(days=3))
+        create_submission(complete_time=today - timezone.timedelta(days=4))
+
+        result = client.get(
+            reverse("submission-list") + "?from=yesterday",
+            content_type="application/json",
+            **headers,
+        )
+        assert result.status_code == status.HTTP_200_OK
+        # should just be the one from 6 hours ago
+        assert len(result.json()["results"]) == 1
+
+        result = client.get(
+            reverse("submission-list") + "?from=day%20before%20yesterday",
+            content_type="application/json",
+            **headers,
+        )
+        assert len(result.json()["results"]) == 2
+
+        result = client.get(
+            reverse("submission-list")
+            + "?from=day%20before%20yesterday&until=yesterday",
+            content_type="application/json",
+            **headers,
+        )
+        assert len(result.json()["results"]) == 1
+
+        result = client.get(
+            reverse("submission-list") + "?from=aaaaaaaaaa",
+            content_type="application/json",
+            **headers,
+        )
+        assert len(result.json()["results"]) == 5

--- a/api/tests/submissions/test_submission_get.py
+++ b/api/tests/submissions/test_submission_get.py
@@ -183,7 +183,7 @@ class TestSubmissionGet:
         assert len(result.json()["results"]) == 1
 
         result = client.get(
-            reverse("submission-list") + "?from=aaaaaaaaaa",
+            reverse("submission-list") + "?from=aaaaaaaaaa&until=aaaaaaaaa",
             content_type="application/json",
             **headers,
         )

--- a/api/tests/submissions/test_submission_get.py
+++ b/api/tests/submissions/test_submission_get.py
@@ -168,6 +168,13 @@ class TestSubmissionGet:
         assert len(result.json()["results"]) == 2
 
         result = client.get(
+            reverse("submission-list") + "?from=day+before+yesterday",
+            content_type="application/json",
+            **headers,
+        )
+        assert len(result.json()["results"]) == 2
+
+        result = client.get(
             reverse("submission-list")
             + "?from=day%20before%20yesterday&until=yesterday",
             content_type="application/json",

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from slack import WebClient
 
 from api.authentication import BlossomApiPermission
+from api.filters import TimeFilter
 from api.helpers import validate_request
 from api.models import Source, Submission, Transcription
 from api.serializers import SubmissionSerializer
@@ -36,14 +37,34 @@ from authentication.models import BlossomUser
         " submission if specified.",
         operation_description="Include the original_id as a query to filter"
         " the submissions on the specified ID.",
-        manual_parameters=[Parameter("original_id", "query", type="string")],
+        manual_parameters=[
+            Parameter("original_id", "query", type="string"),
+            Parameter(
+                "from",
+                "query",
+                type="string",
+                description=(
+                    "Date to use as the start of the returned values."
+                    " Example: from=2021-06-01 will return everything after that date."
+                ),
+            ),
+            Parameter(
+                "until",
+                "query",
+                type="string",
+                description=(
+                    "Date to use as the end of the returned values. Example:"
+                    " until=2021-06-05 will return everything from before that date."
+                ),
+            ),
+        ],
     ),
 )
 class SubmissionViewSet(viewsets.ModelViewSet):
     serializer_class = SubmissionSerializer
     permission_classes = (BlossomApiPermission,)
     queryset = Submission.objects.order_by("id")
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [TimeFilter, DjangoFilterBackend]
     filterset_fields = [
         "id",
         "original_id",

--- a/poetry.lock
+++ b/poetry.lock
@@ -275,6 +275,23 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
+name = "dateparser"
+version = "1.0.0"
+description = "Date parsing library designed to parse dates from HTML pages"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = "*"
+regex = "!=2019.02.19"
+tzlocal = "*"
+
+[package.extras]
+calendars = ["convertdate", "hijri-converter", "convertdate"]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
@@ -886,6 +903,17 @@ pytest = ">=2.7"
 dev = ["pre-commit", "tox"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "0.10.5"
 description = "Add .env support to your django/flask apps in development and deployments"
@@ -942,7 +970,7 @@ hiredis = ["hiredis (>=0.1.3)"]
 name = "regex"
 version = "2021.4.4"
 description = "Alternative regular expression module, to replace re."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1139,6 +1167,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "tzlocal"
+version = "2.1"
+description = "tzinfo object for the local timezone"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytz = "*"
+
+[[package]]
 name = "update-checker"
 version = "0.18.0"
 description = "A python module that will check for package updates."
@@ -1236,7 +1275,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a34978457ea6a56c273f4f73c5782239c41fdd4c5d05aa44c2e5b199fc961fc3"
+content-hash = "1f2ba47236a8684fe4ac71a0a3ea29fa908a50a9668f4b0182722adc089f5748"
 
 [metadata.files]
 aiohttp = [
@@ -1457,6 +1496,10 @@ cryptography = [
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
+]
+dateparser = [
+    {file = "dateparser-1.0.0-py2.py3-none-any.whl", hash = "sha256:17202df32c7a36e773136ff353aa3767e987f8b3e27374c39fd21a30a803d6f8"},
+    {file = "dateparser-1.0.0.tar.gz", hash = "sha256:159cc4e01a593706a15cd4e269a0b3345edf3aef8bf9278a57dac8adf5bf1e4a"},
 ]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
@@ -1768,6 +1811,10 @@ pytest-mock = [
     {file = "pytest-mock-1.13.0.tar.gz", hash = "sha256:e24a911ec96773022ebcc7030059b57cd3480b56d4f5d19b7c370ec635e6aed5"},
     {file = "pytest_mock-1.13.0-py2.py3-none-any.whl", hash = "sha256:67e414b3caef7bff6fc6bd83b22b5bc39147e4493f483c2679bc9d4dc485a94d"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
 python-dotenv = [
     {file = "python-dotenv-0.10.5.tar.gz", hash = "sha256:f254bfd0c970d64ccbb6c9ebef3667ab301a71473569c991253a481f1c98dddc"},
     {file = "python_dotenv-0.10.5-py2.py3-none-any.whl", hash = "sha256:440c7c23d53b7d352f9c94d6f70860242c2f071cf5c029dd661ccb22d64ae42b"},
@@ -1975,6 +2022,10 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
     {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
     {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+]
+tzlocal = [
+    {file = "tzlocal-2.1-py2.py3-none-any.whl", hash = "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"},
+    {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
 ]
 update-checker = [
     {file = "update_checker-0.18.0-py3-none-any.whl", hash = "sha256:cbba64760a36fe2640d80d85306e8fe82b6816659190993b7bdabadee4d4bbfd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ praw = "^7.1.0"
 django-filter = "^2.3.0"
 gunicorn = "^20.1.0"
 honeycomb-beeline = "^2.17.0"
+dateparser = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 better-exceptions = "^0.2.2"


### PR DESCRIPTION
Relevant issue: N/a

## Description:

Allow using query string parameters to filter submission objects. Examples:

```
/api/submission/?from=2021-06-03
/api/submission/?from=2021-06-01&until=2021-07-01
/api/submission?from=yesterday
/api/submission?from=march+7th+at+8pm&until=april+12th+at+2pm
```

Needed for buttercup and data science integrations.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
