### PR TITLE
Fix enum of time_frame parameter for rate endpoint

### DIFF
--- a/api/views/volunteer.py
+++ b/api/views/volunteer.py
@@ -83,7 +83,7 @@ class VolunteerViewSet(viewsets.ModelViewSet):
                 "time_frame",
                 "query",
                 type="string",
-                enum=["hour", "day", "week", "month", "year"],
+                enum=["none", "hour", "day", "week", "month", "year"],
                 description="The time interval to calculate the rate by. "
                 'Must be one of "none", "hour", "day", "week", "month" or "year".'
                 'For example, "none" will return the date of every transcription '


### PR DESCRIPTION
Relevant issue: N/A

## Description:

I forgot to add the "none" option to the `time_frame` parameter of the `volunteer/rate` endpoint, because I'm stupid.
This change makes it show up properly in Swagger.

## Screenshots:

![The "none" option now properly shows up in Swagger for the `time_frame` parameter](https://user-images.githubusercontent.com/13908946/124615614-bab69580-de75-11eb-852e-10be9f40b371.png)

## Checklist:

- [X] Code Quality
- [X] Pep-8
- [ ] Tests (if applicable)
- [X] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
