### PR TITLE
Add query parameter to order API results explicitly

### DIFF
--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -17,6 +17,7 @@ from drf_yasg.openapi import Schema
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.filters import OrderingFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
 from slack import WebClient
@@ -64,7 +65,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
     serializer_class = SubmissionSerializer
     permission_classes = (BlossomApiPermission,)
     queryset = Submission.objects.order_by("id")
-    filter_backends = [TimeFilter, DjangoFilterBackend]
+    filter_backends = [TimeFilter, OrderingFilter, DjangoFilterBackend]
     filterset_fields = [
         "id",
         "original_id",
@@ -76,6 +77,13 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         "archived",
         "content_url",
         "redis_id",
+    ]
+    ordering_fields = [
+        "id",
+        "create_time",
+        "last_update_time",
+        "claim_time",
+        "complete_time",
     ]
 
     @csrf_exempt

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -65,7 +65,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
     serializer_class = SubmissionSerializer
     permission_classes = (BlossomApiPermission,)
     queryset = Submission.objects.order_by("id")
-    filter_backends = [TimeFilter, OrderingFilter, DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, TimeFilter, OrderingFilter]
     filterset_fields = [
         "id",
         "original_id",

--- a/api/views/transcription.py
+++ b/api/views/transcription.py
@@ -12,6 +12,7 @@ from drf_yasg.openapi import Schema
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.filters import OrderingFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -28,7 +29,7 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
     queryset = Transcription.objects.all().order_by("-create_time")
     serializer_class = TranscriptionSerializer
     permission_classes = (BlossomApiPermission,)
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
     filterset_fields = [
         "id",
         "submission",
@@ -37,6 +38,11 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
         "source",
         "url",
         "removed_from_reddit",
+    ]
+    ordering_fields = [
+        "id",
+        "create_time",
+        "last_update_time",
     ]
 
     @csrf_exempt


### PR DESCRIPTION
Relevant issue: Closes #172 

## Description:

This uses the `OrderingFilter` general filter back-end to provide an `ordering` query parameter. This can be used to explicitly control the ordering of the API results.

For example, `/api/submission/?ordering=complete_time` and `api/submission/?ordering=-complete_time` will return the submissions filtered by the time they were completed at, ascending and descending respectively.

I added orderings to the `submission`, `transcription` and `volunteer` endpoints.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
