### PR TITLE
Update honeycomb init to include sample rate

### DIFF
--- a/blossom/instrumentation.py
+++ b/blossom/instrumentation.py
@@ -19,10 +19,13 @@ def post_worker_init(worker: Any) -> None:
     logging.info(f"beeline initialization on process pid {os.getpid()}")
 
     honeycomb_key = os.getenv("HONEYCOMB_KEY", "")
-    if len(honeycomb_key) == 0:
-        # if no api key, do not send data and instead print what would be sent to stderr
-        beeline.init(writekey="", dataset="blossom", debug=True)
-    else:
-        # pass data to honeycomb.io if we have a key
-        beeline.init(writekey=honeycomb_key, dataset="blossom", debug=False)
+    # if no api key, do not send data and instead print what would be sent to stderr
+    # if we have a key, pass data to honeycomb.io
+    args = {
+        "writekey": honeycomb_key,
+        "dataset": "blossom",
+        "debug": True if len(honeycomb_key) == 0 else False,
+        "sample_rate": 10,
+    }
+    beeline.init(**args)
     atexit.register(beeline.close)


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Right now we are sending an insane number of events to Honeycomb -- we need to drastically cut that down in order to fit in our usage tier. Per the documentation suggestion of Beeline (Honeycomb.io's python library that we use) I've set a sampling rate of 10 and we can adjust from there if we don't like it.

## Screenshots:

![image](https://user-images.githubusercontent.com/5179553/126072753-093bb0fa-8fce-4873-9c55-c2b70abba6b6.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
