### PR TITLE
Prevent mass claiming of submissions

### DIFF
--- a/api/tests/submissions/test_submission_claim.py
+++ b/api/tests/submissions/test_submission_claim.py
@@ -123,8 +123,8 @@ class TestSubmissionClaim:
     def test_claim_too_many_claimed(self, client: Client) -> None:
         """Test whether a user who already has claims can claim another post."""
         client, headers, user = setup_user_client(client)
-        create_submission(claimed_by=user)
-        submission = create_submission()
+        create_submission(claimed_by=user, id=1)
+        submission = create_submission(id=2)
 
         data = {"username": user.username}
 
@@ -135,6 +135,9 @@ class TestSubmissionClaim:
             **headers,
         )
         assert result.status_code == 460
+        claimed_submissions = result.json()
+        assert len(claimed_submissions) == 1
+        assert claimed_submissions[0]["id"] == 1
 
     def test_claim_no_coc(self, client: Client) -> None:
         """Test that a claim cannot be completed without accepting the CoC."""

--- a/api/tests/submissions/test_submission_claim.py
+++ b/api/tests/submissions/test_submission_claim.py
@@ -134,7 +134,7 @@ class TestSubmissionClaim:
             content_type="application/json",
             **headers,
         )
-        assert result.status_code == status.HTTP_409_CONFLICT
+        assert result.status_code == 460
 
     def test_claim_no_coc(self, client: Client) -> None:
         """Test that a claim cannot be completed without accepting the CoC."""

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -255,9 +255,9 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             400: "The volunteer username is not provided",
             403: "The volunteer has not accepted the Code of Conduct",
             404: "The specified volunteer or submission is not found",
-            409: "The submission is already claimed "
-            "or the user has already claimed too many posts",
+            409: "The submission is already claimed ",
             423: "The user is blacklisted",
+            460: "The volunteer has already claimed too many posts",
         },
     )
     @validate_request(data_params={"username"})
@@ -288,7 +288,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         for claim_restriction in reversed(MAX_CLAIMS):
             if user.gamma >= claim_restriction["gamma"]:
                 if claimed_count >= claim_restriction["claims"]:
-                    return Response(status=status.HTTP_409_CONFLICT)
+                    return Response(status=460)
                 break
 
         submission.claimed_by = user

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -255,7 +255,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             400: "The volunteer username is not provided",
             403: "The volunteer has not accepted the Code of Conduct",
             404: "The specified volunteer or submission is not found",
-            409: "The submission is already claimed ",
+            409: "The submission is already claimed",
             423: "The user is blacklisted",
             460: "The volunteer has already claimed too many posts",
         },


### PR DESCRIPTION
Relevant issue: Closes #182

## Description:

This enforces a limit on the maximum number of submissions a user can claim at the same time.

When the limit is reached, claiming returns status code `460`  and a list of the claimed submissions. This can then be used by u/tor to warn the user.

## Checklist:

- [X] Code Quality
- [X] Pep-8
- [X] Tests (if applicable)
- [X] Success Criteria Met
- [X] Inline Documentation
- [ ] Wiki Documentation (if applicable)
