### PR TITLE
Return user who already claimed a submission

### DIFF
--- a/api/tests/submissions/test_submission_claim.py
+++ b/api/tests/submissions/test_submission_claim.py
@@ -4,7 +4,7 @@ from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
-from api.tests.helpers import create_submission, setup_user_client
+from api.tests.helpers import create_submission, create_user, setup_user_client
 
 
 class TestSubmissionClaim:
@@ -62,9 +62,12 @@ class TestSubmissionClaim:
         )
         assert result.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_claim_already_claimed(self, client: Client) -> None:
-        """Test whether a claim on a Submission already claimed is successfully caught."""
-        client, headers, user = setup_user_client(client)
+    def test_claim_already_claimed_same_user(self, client: Client) -> None:
+        """Test a claim on a Submission already claimed by the same user.
+
+        This should be prevented and return an error.
+        """
+        client, headers, user = setup_user_client(client, id=1, username="user_1")
         submission = create_submission(claimed_by=user)
         data = {"username": user.username}
 
@@ -75,6 +78,36 @@ class TestSubmissionClaim:
             **headers,
         )
         assert result.status_code == status.HTTP_409_CONFLICT
+        claimed_by = result.json()
+        assert claimed_by["id"] == 1
+        assert claimed_by["username"] == "user_1"
+
+        submission.refresh_from_db()
+        assert submission.claimed_by == user
+
+    def test_claim_already_claimed_other_user(self, client: Client) -> None:
+        """Test a claim on a Submission already claimed by another user.
+
+        This should be prevented and return an error.
+        """
+        client, headers, user = setup_user_client(client, id=1, username="user_1")
+        other_user = create_user(id=2, username="user_2")
+        submission = create_submission(claimed_by=other_user)
+        data = {"username": user.username}
+
+        result = client.patch(
+            reverse("submission-claim", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers,
+        )
+        assert result.status_code == status.HTTP_409_CONFLICT
+        claimed_by = result.json()
+        assert claimed_by["id"] == 2
+        assert claimed_by["username"] == "user_2"
+
+        submission.refresh_from_db()
+        assert submission.claimed_by == other_user
 
     def test_claim_no_coc(self, client: Client) -> None:
         """Test that a claim cannot be completed without accepting the CoC."""

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -28,6 +28,7 @@ from api.helpers import validate_request
 from api.models import Source, Submission, Transcription
 from api.serializers import SubmissionSerializer
 from api.views.slack_helpers import client as slack
+from api.views.volunteer import VolunteerViewSet
 from authentication.models import BlossomUser
 
 
@@ -273,7 +274,12 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         if submission.claimed_by is not None:
-            return Response(status=status.HTTP_409_CONFLICT)
+            return Response(
+                data=VolunteerViewSet.serializer_class(
+                    submission.claimed_by, context={"request": request}
+                ).data,
+                status=status.HTTP_409_CONFLICT,
+            )
 
         submission.claimed_by = user
         submission.claim_time = timezone.now()


### PR DESCRIPTION
Relevant issue: GrafeasGroup/tor#187, Closes #184

## Description:

When a submission is claimed and then tried to claim again, the user who already claimed the submission is returned along with the error code. u/tor can use this to determine if it was the same person or another person and adjust the message accordingly.

## Checklist:

- [X] Code Quality
- [X] Pep-8
- [X] Tests (if applicable)
- [X] Success Criteria Met
- [X] Inline Documentation
- [ ] Wiki Documentation (if applicable)
