### PR TITLE
Make usernames case insensitive

### DIFF
--- a/authentication/models.py
+++ b/authentication/models.py
@@ -1,10 +1,30 @@
 """Models used within the Authentication application."""
-from django.contrib.auth.models import AbstractUser
+from typing import Any
+
+from django.contrib.auth.models import AbstractUser, UserManager
 from django.db import models
+from django.db.models import QuerySet
 from django.utils import timezone
 from rest_framework_api_key.models import APIKey
 
 from api.models import Submission
+
+
+class BlossomUserManager(UserManager):
+    # https://stackoverflow.com/a/7774039
+    def filter(self, **kwargs: Any) -> QuerySet:
+        """Override `filter` to make usernames case insensitive."""
+        if "username" in kwargs:
+            kwargs["username__iexact"] = kwargs["username"]
+            del kwargs["username"]
+        return super().filter(**kwargs)
+
+    def get(self, **kwargs: Any) -> QuerySet:
+        """Override `get` to make usernames case insensitive."""
+        if "username" in kwargs:
+            kwargs["username__iexact"] = kwargs["username"]
+            del kwargs["username"]
+        return super().get(**kwargs)
 
 
 class BlossomUser(AbstractUser):
@@ -43,6 +63,8 @@ class BlossomUser(AbstractUser):
     # Whether the user is blacklisted; if so, all bots will refuse to interact
     # with this user.
     blacklisted = models.BooleanField(default=False)
+
+    objects = BlossomUserManager()
 
     @property
     def gamma(self) -> int:

--- a/authentication/tests/test_blossomusermanager.py
+++ b/authentication/tests/test_blossomusermanager.py
@@ -1,0 +1,36 @@
+"""Set of tests which are used to validate the behavior of the authentication of users."""
+from api.tests.helpers import create_user
+from authentication.models import BlossomUser
+
+USER_CREATION_DATA = {"username": "Narf"}
+
+
+def test_get_case_insensitive_usernames() -> None:
+    """Test whether `get`s that use usernames are properly case insensitive."""
+    create_user(**USER_CREATION_DATA)
+    # all four of these should return the same object
+    for option in ["nArF", "Narf"]:
+        assert BlossomUser.objects.get(username=option)
+        assert BlossomUser.objects.get(username__iexact=option)
+
+
+def test_filter_case_insensitive_usernames() -> None:
+    """Test whether `filter`s that use usernames are properly case insensitive."""
+    create_user(**USER_CREATION_DATA)
+    for option in ["nArF", "Narf"]:
+        assert BlossomUser.objects.filter(username=option).count() == 1
+        assert BlossomUser.objects.filter(username__iexact=option).count() == 1
+
+
+def test_verify_usernames_dont_affect_other_filters() -> None:
+    """Test that case insensitive usernames don't affect other filters."""
+    create_user(**USER_CREATION_DATA)
+
+    for option in ["nArF", "Narf"]:
+        for is_vol in [True, False]:
+            assert BlossomUser.objects.filter(
+                username=option, is_volunteer=is_vol
+            ).count() == (1 if is_vol else 0)
+            assert BlossomUser.objects.filter(
+                username__iexact=option, is_volunteer=is_vol
+            ).count() == (1 if is_vol else 0)


### PR DESCRIPTION
Relevant issue: N/a

## Description:

This PR rewrites all incoming calls to the BlossomUser model to use case-insensitive searching for `.get()` and `.filter()`.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
