### PR TITLE
add production ip address to allowed hosts

### DIFF
--- a/blossom/settings/base.py
+++ b/blossom/settings/base.py
@@ -35,7 +35,7 @@ SECRET_KEY = os.environ.get("BLOSSOM_SECRET_KEY", default_secret_key)
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = ["staging.grafeas.org", ".grafeas.org", "grafeas.org"]
+ALLOWED_HOSTS = ["staging.grafeas.org", ".grafeas.org", "grafeas.org", "170.187.156.84"]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/


### PR DESCRIPTION
Relevant issue: N/a

## Description:

Adds the production machine IP address to the allowed hosts.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
