### PR TITLE
Add title field to submission model

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -119,6 +119,9 @@ class Submission(models.Model):
         Source, default=get_default_source, on_delete=models.CASCADE
     )
 
+    # The title of the submission.
+    title = models.CharField(max_length=300, blank=True, null=True)
+
     # The URL to the Submission directly on its source.
     url = models.URLField(null=True, blank=True)
 

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -77,6 +77,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         "claimed_by",
         "completed_by",
         "source",
+        "title",
         "url",
         "tor_url",
         "archived",
@@ -85,6 +86,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
     ]
     ordering_fields = [
         "id",
+        "title",
         "create_time",
         "last_update_time",
         "claim_time",


### PR DESCRIPTION
Relevant issue: Closes #149.

## Description:

Adds an optional `title` field to the submission model and allows filtering and ordering by title on the submission view. This allows us to fetch the title directly from Blossom instead of having to get it from Reddit.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
