### PR TITLE
Add title attribute to submission serializer

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -60,6 +60,7 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
             "claim_time",
             "complete_time",
             "source",
+            "title",
             "url",
             "tor_url",
             "content_url",


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Adds the `title` attribute to the Submission serializer. This makes it actually visible in the API and also (maybe?) available to the `PATCH` call.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
