### PR TITLE
Add active_volunteer_count to summary endpoint

### DIFF
--- a/api/tests/test_misc.py
+++ b/api/tests/test_misc.py
@@ -1,11 +1,14 @@
 """Test the functionality of the Summary and Ping view."""
+import datetime
+
+import pytz
 from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
 from api.helpers import get_time_since_open
 from api.models import Source, get_default_source
-from api.tests.helpers import setup_user_client
+from api.tests.helpers import create_submission, create_user, setup_user_client
 
 
 def test_ping(client: Client) -> None:
@@ -24,8 +27,32 @@ def test_summary(client: Client) -> None:
     assert "transcription_count" in result.json().keys()
     assert "days_since_inception" in result.json().keys()
     assert "volunteer_count" in result.json().keys()
-    assert len(result.json().keys()) == 3
+    assert "active_volunteer_count" in result.json().keys()
+    assert len(result.json().keys()) == 4
     assert result.status_code == status.HTTP_200_OK
+
+
+def test_active_volunteer_count(client: Client) -> None:
+    """Test whether the summary provides a correct active volunteer count."""
+    client, headers, user_1 = setup_user_client(client, id=123, username="user_1")
+    user_2 = create_user(id=456, username="user_2")
+    user_3 = create_user(id=789, username="user_3")
+
+    now = datetime.datetime.now(tz=pytz.utc)
+    two_days_ago = now - datetime.timedelta(days=2)
+    one_week_ago = now - datetime.timedelta(weeks=1)
+    three_weeks_ago = now - datetime.timedelta(weeks=3)
+    four_weeks_ago = now - datetime.timedelta(weeks=4)
+
+    create_submission(completed_by=user_1, complete_time=two_days_ago)
+    create_submission(completed_by=user_1, complete_time=four_weeks_ago)
+    create_submission(completed_by=user_2, complete_time=three_weeks_ago)
+    create_submission(completed_by=user_3, complete_time=one_week_ago)
+
+    result = client.get(reverse("summary"), content_type="application/json", **headers,)
+
+    assert result.status_code == status.HTTP_200_OK
+    assert result.json()["active_volunteer_count"] == 2
 
 
 def test_days_since_open() -> None:

--- a/api/views/misc.py
+++ b/api/views/misc.py
@@ -1,6 +1,8 @@
 """Views that don't fit in any of the other view files."""
+import datetime
 from typing import Dict
 
+import pytz
 from django.views.decorators.csrf import csrf_exempt
 from drf_yasg.openapi import Response as DocResponse
 from drf_yasg.openapi import Schema
@@ -32,9 +34,17 @@ class Summary(object):
 
         :return: A dictionary containing the three key-value pairs as described
         """
+        date_minus_two_weeks = datetime.datetime.now(tz=pytz.utc) - datetime.timedelta(
+            weeks=2
+        )
         return {
             "volunteer_count": BlossomUser.objects.filter(is_volunteer=True).count()
             - 2,
+            "active_volunteer_count": Submission.objects.filter(
+                completed_by__isnull=False, complete_time__gte=date_minus_two_weeks,
+            )
+            .values("completed_by")
+            .count(),
             "transcription_count": Submission.objects.filter(
                 completed_by__isnull=False
             ).count(),

--- a/api/views/misc.py
+++ b/api/views/misc.py
@@ -44,6 +44,7 @@ class Summary(object):
                 completed_by__isnull=False, complete_time__gte=date_minus_two_weeks,
             )
             .values("completed_by")
+            .distinct()
             .count(),
             "transcription_count": Submission.objects.filter(
                 completed_by__isnull=False


### PR DESCRIPTION
Relevant issue: Closes #198.

## Description:

This counts the number of volunteers who completed a submission in the last two weeks. This gives us a sense of how many volunteers are actually still transcribing.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
