### PR TITLE
Fix TimeFilter backend for timezone aware times

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -1,7 +1,6 @@
 import dateparser
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import Q
-from django.utils import timezone
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.request import Request
 from rest_framework.views import View
@@ -12,22 +11,20 @@ class TimeFilter(BaseFilterBackend):
         self, request: Request, queryset: QuerySet, view: View
     ) -> QuerySet:
         """Attempt to filter a request by time descriptors if available."""
+        dateparser_settings = {
+            "TIMEZONE": "+0000",
+            "RETURN_AS_TIMEZONE_AWARE": True,
+        }
         filters = Q()
         if from_time := request.query_params.get("from"):
-            try:
-                filters = filters & Q(
-                    complete_time__gt=timezone.make_aware(dateparser.parse(from_time))
-                )
-            except AttributeError:
-                pass
+            from_datetime = dateparser.parse(from_time, settings=dateparser_settings)
+            if from_datetime is not None:
+                filters = filters & Q(complete_time__gt=from_datetime)
 
         if until_time := request.query_params.get("until"):
-            try:
-                filters = filters & Q(
-                    complete_time__lt=timezone.make_aware(dateparser.parse(until_time))
-                )
-            except AttributeError:
-                pass
+            until_datetime = dateparser.parse(until_time, settings=dateparser_settings)
+            if until_datetime is not None:
+                filters = filters & Q(complete_time__lt=until_datetime)
 
         return queryset.filter(filters)
 

--- a/api/tests/submissions/test_submission_get.py
+++ b/api/tests/submissions/test_submission_get.py
@@ -104,7 +104,18 @@ class TestSubmissionGet:
         assert "AAA" in result.json()["results"][0]["source"]  # it will be a full link
         assert result.json()["results"][0]["id"] == 1
 
-    def test_list_with_time_filters(self, client: Client) -> None:
+    @pytest.mark.parametrize(
+        "time_query,result_count",
+        [
+            ("from=2021-01-02,1pm", 2),
+            ("from=2021-01-03", 1),
+            ("from=2020-12-31&until=2021-01-05", 4),
+            ("from=2021-01-01T12:00&until=2021-01-03T12:00", 2),
+        ],
+    )
+    def test_list_with_time_filters(
+        self, client: Client, time_query: str, result_count: int
+    ) -> None:
         """Verify that listing submissions using time filters works correctly."""
         client, headers, _ = setup_user_client(client)
 
@@ -114,26 +125,12 @@ class TestSubmissionGet:
         create_submission(complete_time=timezone.make_aware(datetime(2021, 1, 4)))
 
         result = client.get(
-            reverse("submission-list") + "?from=2021-01-02,1pm",
+            reverse("submission-list") + f"?{time_query}",
             content_type="application/json",
             **headers,
         )
         assert result.status_code == status.HTTP_200_OK
-        assert len(result.json()["results"]) == 2
-
-        result = client.get(
-            reverse("submission-list") + "?from=2021-01-03",
-            content_type="application/json",
-            **headers,
-        )
-        assert len(result.json()["results"]) == 1
-
-        result = client.get(
-            reverse("submission-list") + "?from=2020-12-31&until=2021-01-05",
-            content_type="application/json",
-            **headers,
-        )
-        assert len(result.json()["results"]) == 4
+        assert len(result.json()["results"]) == result_count
 
     def test_list_with_advanced_time_filters(self, client: Client) -> None:
         """Verify that listing items with English time filters works properly."""

--- a/api/tests/submissions/test_submission_get.py
+++ b/api/tests/submissions/test_submission_get.py
@@ -111,6 +111,11 @@ class TestSubmissionGet:
             ("from=2021-01-03", 1),
             ("from=2020-12-31&until=2021-01-05", 4),
             ("from=2021-01-01T12:00&until=2021-01-03T12:00", 2),
+            ("from=2021-01-01T12:00:00&until=2021-01-03T12:00:00", 2),
+            ("from=2021-01-01T12:00:00Z&until=2021-01-03T12:00:00Z", 2),
+            ("from=2021-01-01T12:00:00Z&until=2021-01-03T12:00:00", 2),
+            ("from=2021-01-01T12:00:00%2b01:00&until=2021-01-03T12:00:00%2b01:00", 2),
+            ("from=2021-01-01T12:00:00%2b01:00&until=2021-01-03T12:00:00%2b05:00", 2),
         ],
     )
     def test_list_with_time_filters(
@@ -118,6 +123,8 @@ class TestSubmissionGet:
     ) -> None:
         """Verify that listing submissions using time filters works correctly."""
         client, headers, _ = setup_user_client(client)
+
+        print(f"Time filter test {time_query}")
 
         create_submission(complete_time=timezone.make_aware(datetime(2021, 1, 1)))
         create_submission(complete_time=timezone.make_aware(datetime(2021, 1, 2)))
@@ -132,7 +139,19 @@ class TestSubmissionGet:
         assert result.status_code == status.HTTP_200_OK
         assert len(result.json()["results"]) == result_count
 
-    def test_list_with_advanced_time_filters(self, client: Client) -> None:
+    @pytest.mark.parametrize(
+        "time_query,result_count",
+        [
+            ("from=yesterday", 1),
+            ("from=day%20before%20yesterday", 2),
+            ("from=day+before+yesterday", 2),
+            ("from=day%20before%20yesterday&until=yesterday", 1),
+            ("from=aaaaaaaaaa&until=aaaaaaaaa", 5),
+        ],
+    )
+    def test_list_with_advanced_time_filters(
+        self, client: Client, time_query: str, result_count: int
+    ) -> None:
         """Verify that listing items with English time filters works properly."""
         client, headers, _ = setup_user_client(client)
         today = timezone.now()
@@ -144,42 +163,13 @@ class TestSubmissionGet:
         create_submission(complete_time=today - timezone.timedelta(days=4))
 
         result = client.get(
-            reverse("submission-list") + "?from=yesterday",
+            reverse("submission-list") + f"?{time_query}",
             content_type="application/json",
             **headers,
         )
         assert result.status_code == status.HTTP_200_OK
         # should just be the one from 6 hours ago
-        assert len(result.json()["results"]) == 1
-
-        result = client.get(
-            reverse("submission-list") + "?from=day%20before%20yesterday",
-            content_type="application/json",
-            **headers,
-        )
-        assert len(result.json()["results"]) == 2
-
-        result = client.get(
-            reverse("submission-list") + "?from=day+before+yesterday",
-            content_type="application/json",
-            **headers,
-        )
-        assert len(result.json()["results"]) == 2
-
-        result = client.get(
-            reverse("submission-list")
-            + "?from=day%20before%20yesterday&until=yesterday",
-            content_type="application/json",
-            **headers,
-        )
-        assert len(result.json()["results"]) == 1
-
-        result = client.get(
-            reverse("submission-list") + "?from=aaaaaaaaaa&until=aaaaaaaaa",
-            content_type="application/json",
-            **headers,
-        )
-        assert len(result.json()["results"]) == 5
+        assert len(result.json()["results"]) == result_count
 
     @pytest.mark.parametrize(
         "ordering,complete_times,expected_times",


### PR DESCRIPTION
Relevant issue: Closes #202.

## Description:

There was a bug in the implementation of the `TimeFilter` backend that resulted in errors when providing timezone aware time strings as `from` or `until` parameters.

Specifically, it always used `timezone.make_aware` on the parsed time, which fails when the given time is already timezone aware.

Instead, the default timezone is now provided directly to the date parser.

## Checklist:

- [X] Code Quality
- [X] Pep-8
- [X] Tests (if applicable)
- [X] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
