### PR TITLE
Add `isnull` filters to endpoints

### DIFF
--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -86,19 +86,21 @@ class SubmissionViewSet(viewsets.ModelViewSet):
     permission_classes = (BlossomApiPermission,)
     queryset = Submission.objects.order_by("id")
     filter_backends = [DjangoFilterBackend, TimeFilter, OrderingFilter]
-    filterset_fields = [
-        "id",
-        "original_id",
-        "claimed_by",
-        "completed_by",
-        "source",
-        "title",
-        "url",
-        "tor_url",
-        "archived",
-        "content_url",
-        "redis_id",
-    ]
+    filterset_fields = {
+        "id": ["exact"],
+        "original_id": ["exact"],
+        "claimed_by": ["exact", "isnull"],
+        "completed_by": ["exact", "isnull"],
+        "claim_time": ["isnull"],
+        "complete_time": ["isnull"],
+        "source": ["exact"],
+        "title": ["exact", "isnull"],
+        "url": ["exact", "isnull"],
+        "tor_url": ["exact", "isnull"],
+        "archived": ["exact"],
+        "content_url": ["exact", "isnull"],
+        "redis_id": ["exact", "isnull"],
+    }
     ordering_fields = [
         "id",
         "title",

--- a/api/views/transcription.py
+++ b/api/views/transcription.py
@@ -30,15 +30,16 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
     serializer_class = TranscriptionSerializer
     permission_classes = (BlossomApiPermission,)
     filter_backends = [DjangoFilterBackend, OrderingFilter]
-    filterset_fields = [
-        "id",
-        "submission",
-        "author",
-        "original_id",
-        "source",
-        "url",
-        "removed_from_reddit",
-    ]
+    filterset_fields = {
+        "id": ["exact"],
+        "submission": ["exact"],
+        "author": ["exact"],
+        "original_id": ["exact", "isnull"],
+        "source": ["exact"],
+        "url": ["exact", "isnull"],
+        "text": ["isnull"],
+        "removed_from_reddit": ["exact"],
+    }
     ordering_fields = [
         "id",
         "create_time",


### PR DESCRIPTION
Relevant issue: Closes #201

## Description:

This PR adds `isnull` filters to the endpoints, allowing clients to exclude or include `null` entries in the listings. This allows several new queries, such as getting all posts in the queue and getting all in-progress posts by a user.

For example, the submission endpoint now allows query parameters like `?completed_by__isnull=true` which gets all submissions that have not been completed yet.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
