### PR TITLE
Allow processing slack username pings with links in them

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 application-import-names = api,authentication,blossom,blossom_wiki,engineeringblog,ocr,payments,website
-ignore = ANN101, D100, D101, D105, D106, W503,
+ignore = ANN101, D100, D101, D105, D106, W503, E203
 import-order-style = pycharm
 max-complexity = 10
 max-line-length = 90

--- a/api/tests/test_slack.py
+++ b/api/tests/test_slack.py
@@ -237,6 +237,18 @@ def test_process_blacklist() -> None:
     ]["success_undo"].format(test_user.username)
 
 
+def test_process_blacklist_with_slack_link() -> None:
+    """Verify that messages with links in them are processed correctly."""
+    slack_client.chat_postMessage = MagicMock()
+
+    test_user = create_user()
+    assert test_user.blacklisted is False
+    message = f"blacklist <https://reddit.com/example|{test_user.username}>"
+    process_blacklist("", message)
+    test_user.refresh_from_db()
+    assert test_user.blacklisted is True
+
+
 @pytest.mark.parametrize(
     "message,response",
     [
@@ -278,6 +290,19 @@ def test_process_coc_reset() -> None:
     assert slack_client.chat_postMessage.call_args[1]["text"] == i18n["slack"][
         "reset_coc"
     ]["success_undo"].format(test_user.username)
+
+
+def test_process_coc_reset_with_slack_link() -> None:
+    """Verify that messages with links in them are processed correctly."""
+    slack_client.chat_postMessage = MagicMock()
+
+    test_user = create_user()
+    assert test_user.accepted_coc is True
+    message = f"reset <https://reddit.com/example|{test_user.username}>"
+    process_coc_reset("", message)
+    slack_client.chat_postMessage.assert_called_once()
+    test_user.refresh_from_db()
+    assert test_user.accepted_coc is False
 
 
 @pytest.mark.parametrize(

--- a/api/views/slack_helpers.py
+++ b/api/views/slack_helpers.py
@@ -1,5 +1,6 @@
 import binascii
 import hmac
+import logging
 import os
 from typing import Any, Dict, List
 from unittest import mock
@@ -14,6 +15,8 @@ from api.serializers import VolunteerSerializer
 from api.views.misc import Summary
 from authentication.models import BlossomUser
 from blossom.strings import translation
+
+logger = logging.getLogger(__name__)
 
 if settings.ENABLE_SLACK is True:
     client = slack.WebClient(token=os.environ["SLACK_API_KEY"])  # pragma: no cover
@@ -126,6 +129,7 @@ def process_blacklist(channel: str, message: str) -> None:
         # they didn't give a username
         msg = i18n["slack"]["errors"]["missing_username"]
     elif len(parsed_message) == 2:
+        logger.warning(parsed_message)
         if user := BlossomUser.objects.filter(
             username__iexact=parsed_message[1]
         ).first():

--- a/api/views/slack_helpers.py
+++ b/api/views/slack_helpers.py
@@ -174,19 +174,16 @@ def process_coc_reset(channel: str, message: str) -> None:
         # they didn't give a username
         msg = i18n["slack"]["errors"]["missing_username"]
     elif len(parsed_message) == 2:
-        if user := BlossomUser.objects.filter(
-            username__iexact=parsed_message[1]
-        ).first():
+        username = clean_links(parsed_message[1])
+        if user := BlossomUser.objects.filter(username__iexact=username).first():
             if user.accepted_coc:
                 user.accepted_coc = False
                 user.save()
-                msg = i18n["slack"]["reset_coc"]["success"].format(parsed_message[1])
+                msg = i18n["slack"]["reset_coc"]["success"].format(username)
             else:
                 user.accepted_coc = True
                 user.save()
-                msg = i18n["slack"]["reset_coc"]["success_undo"].format(
-                    parsed_message[1]
-                )
+                msg = i18n["slack"]["reset_coc"]["success_undo"].format(username)
         else:
             msg = i18n["slack"]["errors"]["unknown_username"]
 

--- a/api/views/slack_helpers.py
+++ b/api/views/slack_helpers.py
@@ -1,7 +1,7 @@
 import binascii
 import hmac
-import logging
 import os
+import re
 from typing import Any, Dict, List
 from unittest import mock
 
@@ -16,8 +16,6 @@ from api.views.misc import Summary
 from authentication.models import BlossomUser
 from blossom.strings import translation
 
-logger = logging.getLogger(__name__)
-
 if settings.ENABLE_SLACK is True:
     client = slack.WebClient(token=os.environ["SLACK_API_KEY"])  # pragma: no cover
 else:
@@ -25,6 +23,23 @@ else:
     client = mock.Mock()
 
 i18n = translation()
+
+# find a link in the slack format, then strip out the text at the end.
+# they're formatted like this: <https://example.com|Text!>
+SLACK_TEXT_EXTRACTOR = re.compile(
+    r"<(?:https?://)?[\w-]+(?:\.[\w-]+)+\.?(?::\d+)?(?:/\S*)?\|([^>]+)>"
+)
+
+
+def clean_links(text: str) -> str:
+    """Strip link out of auto-generated slack fancy URLS and return the text only."""
+    results = [_ for _ in re.finditer(SLACK_TEXT_EXTRACTOR, text)]
+    # we'll replace things going backwards so that we don't mess up indexing
+    results.reverse()
+
+    for match in results:
+        text = text[: match.start()] + match.groups()[0] + text[match.end() :]
+    return text
 
 
 def dict_to_table(dictionary: Dict, titles: List = None, width: int = None) -> List:
@@ -129,20 +144,16 @@ def process_blacklist(channel: str, message: str) -> None:
         # they didn't give a username
         msg = i18n["slack"]["errors"]["missing_username"]
     elif len(parsed_message) == 2:
-        logger.warning(parsed_message)
-        if user := BlossomUser.objects.filter(
-            username__iexact=parsed_message[1]
-        ).first():
+        username = clean_links(parsed_message[1])
+        if user := BlossomUser.objects.filter(username__iexact=username).first():
             if user.blacklisted:
                 user.blacklisted = False
                 user.save()
-                msg = i18n["slack"]["blacklist"]["success_undo"].format(
-                    parsed_message[1]
-                )
+                msg = i18n["slack"]["blacklist"]["success_undo"].format(username)
             else:
                 user.blacklisted = True
                 user.save()
-                msg = i18n["slack"]["blacklist"]["success"].format(parsed_message[1])
+                msg = i18n["slack"]["blacklist"]["success"].format(username)
         else:
             msg = i18n["slack"]["errors"]["unknown_username"]
     else:

--- a/bootstrap/helpers.py
+++ b/bootstrap/helpers.py
@@ -98,6 +98,12 @@ class User(object):
         self.user_data.update({"username": self.username})
         return self.user_data
 
+    def to_dict(self):
+        return self.user_data
+
+    def get_username(self):
+        return self.user_data.get("username")
+
 
 def get_transcribot_text(comments: List, post_id: str):
     # Try to pull the transcribot comment too


### PR DESCRIPTION
Relevant issue: N/a

## Description:

Enable processing of copy / pasted usernames with fancy links in slack.

Example, existing implementation:

```
@blossom reset itsthejoker  # would work
@blossom reset <https://reddit.com/example|itsthejoker>  # slack can automatically carry that formatting if copied and pasted, and this would not work
```

With this PR, both of those commands will function as expected. Also ported for the `blacklist` command.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
