### PR TITLE
Add transcription time filters

### DIFF
--- a/api/tests/test_transcriptions.py
+++ b/api/tests/test_transcriptions.py
@@ -159,6 +159,33 @@ class TestTranscriptionCreation:
         assert result.status_code == status.HTTP_200_OK
         assert len(result.json()["results"]) == result_count
 
+    def test_list_with_time_filters(self, client: Client) -> None:
+        """Verify that the transcriptions can be filtered by time."""
+        client, headers, user = setup_user_client(client)
+
+        dates = [
+            datetime(2021, 1, 1),
+            datetime(2021, 2, 1),
+            datetime(2021, 2, 3),
+            datetime(2021, 5, 10),
+        ]
+
+        for date in dates:
+            create_transcription(
+                create_submission(), user, create_time=make_aware(date)
+            )
+
+        result = client.get(
+            reverse("transcription-list")
+            + "?create_time__gte=2021-02-01T00:00:00Z"
+            + "&create_time__lte=2021-04-01T00:00:00Z",
+            content_type="application/json",
+            **headers,
+        )
+
+        assert result.status_code == status.HTTP_200_OK
+        assert len(result.json()["results"]) == 2
+
     def test_create(self, client: Client) -> None:
         """Test whether the creation functions correctly when invoked correctly."""
         client, headers, user = setup_user_client(client)

--- a/api/views/transcription.py
+++ b/api/views/transcription.py
@@ -39,6 +39,7 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
         "url": ["exact", "isnull"],
         "text": ["isnull", "icontains"],
         "removed_from_reddit": ["exact"],
+        "create_time": ["gt", "gte", "lte", "lt"],
     }
     ordering_fields = [
         "id",


### PR DESCRIPTION
Relevant issue: Closes #221, required by GrafeasGroup/buttercup#106.

## Description:

This adds `create_time__gt`/`create_time__gte`/`create_time__lte`/`create_time__lt` query parameters to the transcription endpoints to filter the transcriptions by time.

In the future, I plan to also replace the submission time filter by this system. This would allow the client to filter by `create_time`, `claim_time` and `complete_time` separately. However, that would be a breaking change so I'll do it in another PR.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
