### PR TITLE
add slack verification

### DIFF
--- a/api/views/slack.py
+++ b/api/views/slack.py
@@ -6,6 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from api.views.slack_helpers import (
     is_valid_github_request,
+    is_valid_slack_request,
     process_message,
     send_github_sponsors_message,
 )
@@ -45,6 +46,8 @@ def slack_endpoint(request: HttpRequest) -> HttpResponse:
     :param request: HttpRequest
     :return: HttpRequest
     """
+    if not is_valid_slack_request(request):
+        return HttpResponse(status=200)
     json_data = json.loads(request.body)
     if json_data.get("challenge"):
         # looks like we got hit with the magic handshake packet. Send it

--- a/api/views/slack_helpers.py
+++ b/api/views/slack_helpers.py
@@ -295,7 +295,6 @@ def is_valid_github_request(request: HttpRequest) -> bool:
 def is_valid_slack_request(request: HttpRequest) -> bool:
     """Verify that a webhook from Slack is actually from them."""
     # adapted from https://api.slack.com/authentication/verifying-requests-from-slack
-    breakpoint()
     if (slack_signature := request.headers.get("X-Slack-Signature")) is None:
         return False
 

--- a/blossom/settings/base.py
+++ b/blossom/settings/base.py
@@ -201,6 +201,7 @@ ARCHIVIST_COMPLETED_DELAY_TIME = 0.5
 # Global flag; if this is set to False, all slack calls will fail silently
 ENABLE_SLACK = True
 
+SLACK_SIGNING_SECRET = os.environ.get("SLACK_SIGNING_SECRET", "")
 GITHUB_SPONSORS_SECRET_KEY = os.environ.get("GITHUB_SPONSORS_SECRET_KEY", "")
 
 # Global flag; if this is set to False, all calls to ocr.space will fail silently


### PR DESCRIPTION
Relevant issue: N/a

## Description:

Need to actually verify that requests coming in on the slack endpoint actually come from slack. This is a security hole and also since I'm about to implement a command that modifies data, we need to be extra sure. The actual process for verifying is a pain in the butt, but I think that this is accurate.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met (I hope)
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
