### PR TITLE
Enable `/find/` endpoint

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -9,6 +9,7 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
 
 from api.views import (
+    find,
     misc,
     plausible,
     slack,
@@ -74,6 +75,7 @@ router.register(r"source", source.SourceViewSet, basename="source")
 urlpatterns = [
     url(r"", include(router.urls)),
     url(r"^summary/", misc.SummaryView.as_view(), name="summary"),
+    url(r"^find/", find.FindView.as_view(), name="summary"),
     url(
         r"^swagger(?P<format>\.json|\.yaml)$",
         schema_view.without_ui(cache_timeout=0),

--- a/api/urls.py
+++ b/api/urls.py
@@ -75,7 +75,7 @@ router.register(r"source", source.SourceViewSet, basename="source")
 urlpatterns = [
     url(r"", include(router.urls)),
     url(r"^summary/", misc.SummaryView.as_view(), name="summary"),
-    url(r"^find/", find.FindView.as_view(), name="summary"),
+    url(r"^find/", find.FindView.as_view(), name="find"),
     url(
         r"^swagger(?P<format>\.json|\.yaml)$",
         schema_view.without_ui(cache_timeout=0),


### PR DESCRIPTION
Relevant issue: Closes #225.

## Description:

In #223 I added the `/find/` endpoints to get submissions/transcriptions by their URL, but I forgot to actually enable it for usage.
This PR fixes this problem, so that we can actually use it.

It also improves/fixes the Swagger documentation for the endpoint.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
