### PR TITLE
Fix Domain Names

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,5 +2,5 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = beeline,better_exceptions,blossom_wrapper,django,django_filters,dotenv,dpath,drf_yasg,ipware,markdown,mimesis,praw,prawcore,psaw,pytest,pytest_django,pytz,requests,rest_framework,rest_framework_api_key,revproxy,slack,social_core,social_django,stripe,toml
+known_third_party = beeline,better_exceptions,blossom_wrapper,decorator_include,django,django_filters,dotenv,dpath,drf_yasg,ipware,markdown,mimesis,praw,prawcore,psaw,pytest,pytest_django,pytz,requests,rest_framework,rest_framework_api_key,revproxy,slack,social_core,social_django,stripe,toml
 skip=venv,.venv,env,migrations

--- a/blossom/settings/base.py
+++ b/blossom/settings/base.py
@@ -215,6 +215,10 @@ USE_TZ = True
 
 SITE_ID = 1
 
+# Force the request to appear as coming from one site or another in debug mode.
+# Set to the hostname from allowed hosts; for example, "grafeas.org".
+OVERRIDE_HOST = None
+
 OVERRIDE_API_AUTH = False
 
 # number of hours to allow a post to stay up

--- a/blossom/templates/website/generic_form.html
+++ b/blossom/templates/website/generic_form.html
@@ -117,7 +117,7 @@
             </div>
             </form>
         </div>
-        {% if 'login' in request.path %}
+        {% if 'login' in request.path and request.get_host == "thetranscription.app" %}
             <div class="row mt-3">
                 <div class="col-md-1 col-lg-2"></div>
                 <div class="col-md-10 col-lg-8">

--- a/blossom/templates/website/index.html
+++ b/blossom/templates/website/index.html
@@ -4,7 +4,6 @@
 {% load fun_footers %}
 
 {% block content %}
-    YOU ARE: {{ request.user }}
     {% if not posts %}
         <p>
         <h1 class="text-center">

--- a/blossom/urls.py
+++ b/blossom/urls.py
@@ -8,7 +8,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpRequest
 from django.shortcuts import redirect
-from django.urls import path
+from django.urls import include, path
 
 from authentication.views import LoginView
 from website.views import user_create
@@ -50,6 +50,7 @@ def force_domain(domain: str) -> Any:
 urlpatterns = [
     path("superadmin/newuser", user_create, name="user_create"),
     path("superadmin/", admin.site.urls),
+    path("", include("authentication.urls")),
     path("api/", decorator_include(force_domain("grafeas.org"), "api.urls")),
     path("payments/", decorator_include(force_domain("grafeas.org"), "payments.urls")),
     path(

--- a/poetry.lock
+++ b/poetry.lock
@@ -339,6 +339,20 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-decorator-include"
+version = "3.0"
+description = "Include Django URL patterns with decorators"
+category = "main"
+optional = false
+python-versions = ">=3.4"
+
+[package.dependencies]
+Django = ">=2.0"
+
+[package.extras]
+dev = ["flake8", "isort"]
+
+[[package]]
 name = "django-filter"
 version = "2.4.0"
 description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
@@ -1402,7 +1416,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "3d90eb8cd1b270c4503e9648913d97a30158d9105c458991f15b46f04444c0c3"
+content-hash = "268b4eca29f76c6ec3f75a47e6694157e1c573b5ae0d4fcefb6b04f4e28b1a2c"
 
 [metadata.files]
 aiohttp = [
@@ -1700,6 +1714,10 @@ distlib = [
 django = [
     {file = "Django-3.2.10-py3-none-any.whl", hash = "sha256:df6f5eb3c797b27c096d61494507b7634526d4ce8d7c8ca1e57a4fb19c0738a3"},
     {file = "Django-3.2.10.tar.gz", hash = "sha256:074e8818b4b40acdc2369e67dcd6555d558329785408dcd25340ee98f1f1d5c4"},
+]
+django-decorator-include = [
+    {file = "django-decorator-include-3.0.tar.gz", hash = "sha256:18db98e0e48dbb3977ab79b5520dbf5ecbb35f0bced8e15ed62dc66762345856"},
+    {file = "django_decorator_include-3.0-py3-none-any.whl", hash = "sha256:fe7a96afb23f66dcbc6227d3c48430e53cc5704eab30841ddb8bd940e5ea8a5a"},
 ]
 django-filter = [
     {file = "django-filter-2.4.0.tar.gz", hash = "sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ django-revproxy = {git = "https://github.com/hcpuk/django-revproxy.git"}
 Markdown = "^3.3.6"
 django-ipware = "^4.0.0"
 django-mathfilters = "^1.0.0"
+django-decorator-include = "^3.0"
 
 [tool.poetry.dev-dependencies]
 better-exceptions = "^0.2.2"

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
 
-from authentication.urls import urlpatterns as auth_urls
 from website import views
 
 urlpatterns = [
@@ -17,5 +16,3 @@ urlpatterns = [
     path("posts/<str:slug>/edit/", views.PostUpdate.as_view(), name="post_update",),
     path("admin/", views.AdminView.as_view(), name="admin_view"),
 ]
-
-urlpatterns += auth_urls


### PR DESCRIPTION
Relevant issue: N/a

## Description:

So we have a minor problem. The transcription app is designed to be accessed from thetranscription.app and the rest of the site is designed to be accessed from grafeas.org... and they shouldn't share resources. We don't want thetranscription.app/payments to respond to things, after all. This PR adds in a simple redirect system so that if you try to come into a route that is meant for the other domain, the server issues you a 302 so that you can load it from the proper domain name. I can't properly test this without deploying it, but it seems to work; I also fixed the DNS issues so now thetranscription.app actually resolves.

The other major issue is that in order to authenticate with Reddit, we need to give it one URL -- so we basically have to force login to only appear on one domain name. If you try to authenticate to reddit from thetranscription.app but it expects grafeas.org, it'll explode (and vice versa).

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
