### PR TITLE
Fix url parameter of find endpoint not being extracted properly

### DIFF
--- a/api/views/find.py
+++ b/api/views/find.py
@@ -1,6 +1,5 @@
 from typing import Optional, TypedDict
 from urllib.parse import urlparse
-from urllib.request import Request
 
 from django.views.decorators.csrf import csrf_exempt
 from drf_yasg.openapi import Parameter
@@ -8,6 +7,7 @@ from drf_yasg.openapi import Response as DocResponse
 from drf_yasg.openapi import Schema
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -114,6 +114,7 @@ class FindView(APIView):
                 "Can be a submission URL, a ToR submission URL or a transcription URL.",
             ),
         ],
+        required=["url"],
         responses={
             200: DocResponse(
                 "The URL has been found!",
@@ -131,8 +132,9 @@ class FindView(APIView):
             404: "The corresponding submission/transcription could not be found.",
         },
     )
-    def get(self, request: Request, url: str) -> Response:
+    def get(self, request: Request) -> Response:
         """Find the submission/transcription corresponding to the URL."""
+        url = request.query_params.get("url")
         normalized_url = normalize_url(url)
         if normalized_url is None:
             return Response(data="Invalid URL.", status=status.HTTP_400_BAD_REQUEST,)

--- a/api/views/find.py
+++ b/api/views/find.py
@@ -112,6 +112,7 @@ class FindView(APIView):
                 type="string",
                 description="The URL to find the object of. "
                 "Can be a submission URL, a ToR submission URL or a transcription URL.",
+                required=True,
             ),
         ],
         required=["url"],


### PR DESCRIPTION
Relevant issue: N/A

## Description:

While the `/find/` endpoint was finally visible, it always returned an error response.
Turns out that the `url` query parameter wasn't extracted properly so the value was always `None`.

I more or less tested it on the local setup so it should actually work now (hopefully).

Additionally, this fixes some types and makes the `url` parameter required.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
