### PR TITLE
Add custom serializer for the response of the find endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -12,7 +12,6 @@ from django.contrib.auth.models import User
 from rest_framework import serializers
 
 from api.models import Source, Submission, Transcription
-from api.views.find import FindResponse
 from authentication.models import BlossomUser
 
 
@@ -114,7 +113,8 @@ class FindResponseSerializer(serializers.Serializer):
     transcription = TranscriptionSerializer(required=False)
     author = VolunteerSerializer(required=False)
 
-    def create(self, validated_data: Any) -> FindResponse:
+    # We cannot type this properly without circular imports
+    def create(self, validated_data: Any) -> Any:
         """Create an object based on the validated data."""
         submission = validated_data.get("submission")
         transcription = validated_data.get("transcription", None)
@@ -126,7 +126,8 @@ class FindResponseSerializer(serializers.Serializer):
             "author": BlossomUser(**author) if author else None,
         }
 
-    def update(self, instance: FindResponse, validated_data: Any) -> FindResponse:
+    # We cannot type this properly without circular imports
+    def update(self, instance: Any, validated_data: Any) -> Any:
         """Update the object based on the validated data."""
         instance.submission = validated_data.get("submission")
         instance.transcription = validated_data.get("transcription", None)

--- a/api/views/find.py
+++ b/api/views/find.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.models import Submission, Transcription
+from api.serializers import FindResponseSerializer
 from authentication.models import BlossomUser
 
 
@@ -147,4 +148,9 @@ class FindView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        return Response(data=data, status=status.HTTP_200_OK)
+        print(data)
+
+        return Response(
+            data=FindResponseSerializer(data, context={"request": request}).data,
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This is another PR on the long road of fixing the `/find/` endpoint.
Here, we are adding a custom serializer for the response, so that we don't get type errors.

I could confirm on my local instance that the submission is now returned properly and that no error occurs.
Whether the author and transcription are also returned correctly is hard to test locally without creating and patching a bunch of objects. So I'm hoping that this will be the last PR.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
