### PR TITLE
Simplify logic to find posts in `/find/` endpoint

### DIFF
--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -180,6 +180,14 @@ def test_find_by_transcription_url(client: Client, url: str, expected: bool) -> 
             "https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",
             True,
         ),
+        # Transcription URL
+        ("https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/", True),
+        # Shared transcription URL
+        (
+            "https://www.reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/"
+            "?utm_source=share&utm_medium=web2x&context=3",
+            True,
+        ),
         # Other submission URL
         (
             "https://reddit.com/r/aaaaaaacccccccce/comments/q1t6kh/not_so_sure_about_the_demiboy_thing_anymore_im/",
@@ -188,6 +196,11 @@ def test_find_by_transcription_url(client: Client, url: str, expected: bool) -> 
         # Other ToR URL
         (
             "https://reddit.com/r/TranscribersOfReddit/comments/q1ucl3/aaaaaaacccccccce_image_not_so_sure_about_the/",
+            False,
+        ),
+        # Other Transcription URL
+        (
+            "https://reddit.com/r/NonPoliticalTwitter/comments/rn02rf/subtitles/hppsgrs/",
             False,
         ),
     ],

--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -7,7 +7,7 @@ from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
-from api.views.find import find_by_submission_url, normalize_url
+from api.views.find import extract_core_url, find_by_submission_url, normalize_url
 from utils.test_helpers import (
     create_submission,
     create_transcription,
@@ -59,6 +59,17 @@ from utils.test_helpers import (
 def test_normalize_url(url: str, expected: Optional[str]) -> None:
     """Verify that the URL is normalized correctly."""
     actual = normalize_url(url)
+    assert actual == expected
+
+
+def test_extract_core_url() -> None:
+    """Verify that the core URL is extracted correctly."""
+    url = (
+        "https://reddit.com/r/TranscribersOfReddit/comments/plmx5n/"
+        + "curatedtumblr_image_im_an_atheist_but_yall_need/"
+    )
+    expected = "https://reddit.com/r/TranscribersOfReddit/comments/plmx5n"
+    actual = extract_core_url(url)
     assert actual == expected
 
 

--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -7,11 +7,7 @@ from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
-from api.views.find import (
-    find_by_submission_url,
-    find_by_transcription_url,
-    normalize_url,
-)
+from api.views.find import find_by_submission_url, normalize_url
 from utils.test_helpers import (
     create_submission,
     create_transcription,
@@ -113,54 +109,6 @@ def test_find_by_submission_url(
     )
 
     actual = find_by_submission_url(url, url_type)
-
-    if expected:
-        assert actual["submission"] == submission
-        assert actual["transcription"] == transcription
-        assert actual["author"] == user
-    else:
-        assert actual is None
-
-
-@pytest.mark.parametrize(
-    "url,expected",
-    [
-        # Transcription URL
-        ("https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/", True),
-        # Submission URL
-        ("https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/", False),
-        # ToR Submission URL
-        (
-            "https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",
-            False,
-        ),
-        # Other Transcription URL
-        (
-            "https://reddit.com/r/NonPoliticalTwitter/comments/rn02rf/subtitles/hppsgrs/",
-            False,
-        ),
-    ],
-)
-def test_find_by_transcription_url(client: Client, url: str, expected: bool) -> None:
-    """Verify that a transcription is found by its URL."""
-    client, headers, user = setup_user_client(client, id=123, username="test_user")
-
-    submission = create_submission(
-        claimed_by=user,
-        completed_by=user,
-        url="https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/",
-        tor_url="https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",
-        content_url="https://i.redd.it/upwchc4bqhr71.jpg",
-        title="Work is work",
-    )
-
-    transcription = create_transcription(
-        submission=submission,
-        user=user,
-        url="https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/",
-    )
-
-    actual = find_by_transcription_url(url)
 
     if expected:
         assert actual["submission"] == submission

--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -76,8 +76,12 @@ def test_extract_core_url() -> None:
 @pytest.mark.parametrize(
     "url,url_type,expected",
     [
+        # Submission Core URL
+        ("https://reddit.com/r/antiwork/comments/q1tlcf", "url", True),
         # Submission URL
-        ("https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/", "url", True,),
+        ("https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/", "url", True),
+        # ToR Submission Core URL
+        ("https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc", "tor_url", True,),
         # ToR Submission URL
         (
             "https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",
@@ -139,12 +143,24 @@ def test_find_by_submission_url(
             "https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",
             True,
         ),
+        # ToR comment URL
+        (
+            "https://www.reddit.com/r/TranscribersOfReddit/comments/q1tnhc/comment/hfgp1g7/"
+            + "?utm_source=share&utm_medium=web2x&context=3",
+            True,
+        ),
         # Transcription URL
         ("https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/", True),
         # Shared transcription URL
         (
             "https://www.reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/"
-            "?utm_source=share&utm_medium=web2x&context=3",
+            + "?utm_source=share&utm_medium=web2x&context=3",
+            True,
+        ),
+        # Submission comment URL
+        (
+            "https://www.reddit.com/r/antiwork/comments/q1tlcf/comment/hfgttrw/"
+            + "?utm_source=share&utm_medium=web2x&context=3",
             True,
         ),
         # Other submission URL

--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -7,7 +7,11 @@ from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
-from api.views.find import find_by_submission_url, normalize_url
+from api.views.find import (
+    find_by_submission_url,
+    find_by_transcription_url,
+    normalize_url,
+)
 from utils.test_helpers import (
     create_submission,
     create_transcription,
@@ -121,8 +125,56 @@ def test_find_by_submission_url(
 @pytest.mark.parametrize(
     "url,expected",
     [
+        # Transcription URL
+        ("https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/", True),
         # Submission URL
-        ("https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/", True,),
+        ("https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/", False),
+        # ToR Submission URL
+        (
+            "https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",
+            False,
+        ),
+        # Other Transcription URL
+        (
+            "https://reddit.com/r/NonPoliticalTwitter/comments/rn02rf/subtitles/hppsgrs/",
+            False,
+        ),
+    ],
+)
+def test_find_by_transcription_url(client: Client, url: str, expected: bool) -> None:
+    """Verify that a transcription is found by its URL."""
+    client, headers, user = setup_user_client(client, id=123, username="test_user")
+
+    submission = create_submission(
+        claimed_by=user,
+        completed_by=user,
+        url="https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/",
+        tor_url="https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",
+        content_url="https://i.redd.it/upwchc4bqhr71.jpg",
+        title="Work is work",
+    )
+
+    transcription = create_transcription(
+        submission=submission,
+        user=user,
+        url="https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/",
+    )
+
+    actual = find_by_transcription_url(url)
+
+    if expected:
+        assert actual["submission"] == submission
+        assert actual["transcription"] == transcription
+        assert actual["author"] == user
+    else:
+        assert actual is None
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Submission URL
+        ("https://reddit.com/r/antiwork/comments/q1tlcf/work_is_work/", True),
         # ToR Submission URL
         (
             "https://reddit.com/r/TranscribersOfReddit/comments/q1tnhc/antiwork_image_work_is_work/",

--- a/api/views/find.py
+++ b/api/views/find.py
@@ -83,7 +83,7 @@ def find_by_url(url: str) -> Optional[FindResponse]:
         # The fifth segment (index 4) of the link is the sub name
         url_type = "tor_url" if url_parts[4] == "TranscribersOfReddit" else "url"
         return find_by_submission_url(url, url_type)
-    elif len(url_parts) == 11:
+    elif len(url_parts) == 10:
         # It's a link to a comment
         if url_parts[4] == "TranscribersOfReddit":
             # It's a comment on ToR, e.g. a "claim" comment

--- a/api/views/find.py
+++ b/api/views/find.py
@@ -58,7 +58,12 @@ def find_by_submission_url(url: str, url_type: str) -> Optional[FindResponse]:
 
 def find_by_transcription_url(url: str) -> Optional[FindResponse]:
     """Find the objects by a transcription URL."""
-    transcription = Transcription.objects.get(url=url)
+    transcriptions = Transcription.objects.filter(url=url)
+
+    if transcriptions.count() == 0:
+        return None
+
+    transcription = transcriptions[0]
     author = transcription.author
     submission = transcription.submission
 

--- a/api/views/find.py
+++ b/api/views/find.py
@@ -57,6 +57,19 @@ def find_by_submission_url(url: str, url_type: str) -> Optional[FindResponse]:
     return {"submission": submission, "author": author, "transcription": transcription}
 
 
+def extract_core_url(url: str) -> str:
+    """Extract the minimal unique part of the URL.
+
+    https://reddit.com/r/TranscribersOfReddit/comments/plmx5n/curatedtumblr_image_im_an_atheist_but_yall_need/
+    will be converted to
+    https://reddit.com/r/TranscribersOfReddit/comments/plmx5n
+
+    This way we can handle submissions and comments uniformly.
+    """
+    url_parts = url.split("/")
+    return "/".join(url_parts[:7])
+
+
 def find_by_url(url: str) -> Optional[FindResponse]:
     """Find the objects by a normalized URL.
 
@@ -65,10 +78,7 @@ def find_by_url(url: str) -> Optional[FindResponse]:
     """
     url_parts = url.split("/")
     subreddit = url_parts[4]
-    # The unique part of the URL, which also contains the ID of the submission
-    # Comment URLs will be shortened to the submission URL part
-    # E.g.: https://reddit.com/r/TranscribersOfReddit/comments/q1ucl3
-    core_url = "/".join(url_parts[:7])
+    core_url = extract_core_url(url)
 
     if subreddit.casefold() == "transcribersofreddit":
         # Find the submission on ToR


### PR DESCRIPTION
Relevant issue: Closes #234

## Description:

The `/find/` endpoint will now truncate the given URL to the minimal part that still contains the ID of the submission.
It then tries to find the submission with a `startswith` filter.

This greatly simplifies the logic, because we don't have to handle transcriptions separately anymore.
Additionally we can handle more types of URLs, for example `claim`/`done` comments can be found now.
Transcriptions not being found has also been fixed.

The only downside is that it might be slower, because we cannot use simple equality checks anymore.
Personally, I think this is worth it.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
