### PR TITLE
Add OCR to `/find/` response

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -111,26 +111,30 @@ class FindResponseSerializer(serializers.Serializer):
 
     # We just delegate to the serializers of the models
     submission = SubmissionSerializer()
-    transcription = TranscriptionSerializer(required=False)
     author = VolunteerSerializer(required=False)
+    transcription = TranscriptionSerializer(required=False)
+    ocr = TranscriptionSerializer(required=False)
 
     # We cannot type this properly without circular imports
     def create(self, validated_data: Any) -> Any:
         """Create an object based on the validated data."""
         submission = validated_data.get("submission")
-        transcription = validated_data.get("transcription", None)
         author = validated_data.get("author", None)
+        transcription = validated_data.get("transcription", None)
+        ocr = validated_data.get("ocr", None)
 
         return {
             "submission": Submission(**submission),
-            "transcription": Transcription(**transcription) if transcription else None,
             "author": BlossomUser(**author) if author else None,
+            "transcription": Transcription(**transcription) if transcription else None,
+            "ocr": Transcription(**ocr) if ocr else None,
         }
 
     # We cannot type this properly without circular imports
     def update(self, instance: Any, validated_data: Any) -> Any:
         """Update the object based on the validated data."""
         instance.submission = validated_data.get("submission")
-        instance.transcription = validated_data.get("transcription", None)
         instance.author = validated_data.get("author", None)
+        instance.transcription = validated_data.get("transcription", None)
+        instance.ocr = validated_data.get("ocr", None)
         return instance

--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -11,6 +11,7 @@ from api.views.find import extract_core_url, find_by_submission_url, normalize_u
 from utils.test_helpers import (
     create_submission,
     create_transcription,
+    create_user,
     setup_user_client,
 )
 
@@ -88,6 +89,12 @@ def test_extract_core_url() -> None:
             "tor_url",
             True,
         ),
+        # OCR URL
+        (
+            "https://www.reddit.com/r/TranscribersOfReddit/comments/q1tnhc/comment/hfgp1gt/",
+            "tor_url",
+            True,
+        ),
         # Other submission URL
         (
             "https://reddit.com/r/aaaaaaacccccccce/comments/q1t6kh/not_so_sure_about_the_demiboy_thing_anymore_im/",
@@ -118,17 +125,29 @@ def test_find_by_submission_url(
     )
 
     transcription = create_transcription(
+        id=555,
         submission=submission,
         user=user,
         url="https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/",
     )
 
+    ocr_bot = create_user(id=333, username="ocr_bot", is_volunteer=False)
+
+    ocr = create_transcription(
+        id=666,
+        submission=submission,
+        user=ocr_bot,
+        url="https://www.reddit.com/r/TranscribersOfReddit/comments/q1tnhc/comment/hfgp1gt/",
+    )
+
     actual = find_by_submission_url(url, url_type)
 
     if expected:
+        assert actual is not None
         assert actual["submission"] == submission
-        assert actual["transcription"] == transcription
         assert actual["author"] == user
+        assert actual["transcription"] == transcription
+        assert actual["ocr"] == ocr
     else:
         assert actual is None
 
@@ -157,6 +176,11 @@ def test_find_by_submission_url(
             + "?utm_source=share&utm_medium=web2x&context=3",
             True,
         ),
+        # OCR URL
+        (
+            "https://www.reddit.com/r/TranscribersOfReddit/comments/q1tnhc/comment/hfgp1gt/",
+            True,
+        ),
         # Submission comment URL
         (
             "https://www.reddit.com/r/antiwork/comments/q1tlcf/comment/hfgttrw/"
@@ -182,7 +206,9 @@ def test_find_by_submission_url(
 )
 def test_find(client: Client, url: str, expected: bool) -> None:
     """Verify that the posts can be found by their URL."""
-    client, headers, user = setup_user_client(client, id=123, username="test_user")
+    client, headers, user = setup_user_client(
+        client, id=123, username="test_user", is_volunteer=True
+    )
 
     submission = create_submission(
         claimed_by=user,
@@ -194,9 +220,19 @@ def test_find(client: Client, url: str, expected: bool) -> None:
     )
 
     transcription = create_transcription(
+        id=555,
         submission=submission,
         user=user,
         url="https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/",
+    )
+
+    ocr_bot = create_user(id=333, username="ocr_bot", is_volunteer=False)
+
+    ocr = create_transcription(
+        id=666,
+        submission=submission,
+        user=ocr_bot,
+        url="https://www.reddit.com/r/TranscribersOfReddit/comments/q1tnhc/comment/hfgp1gt/",
     )
 
     result = client.get(
@@ -208,7 +244,8 @@ def test_find(client: Client, url: str, expected: bool) -> None:
         actual = result.json()
 
         assert actual["submission"]["id"] == submission.id
-        assert actual["transcription"]["id"] == transcription.id
         assert actual["author"]["id"] == user.id
+        assert actual["transcription"]["id"] == transcription.id
+        assert actual["ocr"]["id"] == ocr.id
     else:
         assert result.status_code == status.HTTP_404_NOT_FOUND

--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -89,12 +89,6 @@ def test_extract_core_url() -> None:
             "tor_url",
             True,
         ),
-        # OCR URL
-        (
-            "https://www.reddit.com/r/TranscribersOfReddit/comments/q1tnhc/comment/hfgp1gt/",
-            "tor_url",
-            True,
-        ),
         # Other submission URL
         (
             "https://reddit.com/r/aaaaaaacccccccce/comments/q1t6kh/not_so_sure_about_the_demiboy_thing_anymore_im/",


### PR DESCRIPTION
Relevant issue: Closes #235 

## Description:

The `/find/` endpoint will now also create the OCR transcription if one is available for the given post.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
