### PR TITLE
Mark transcription text as safe

### DIFF
--- a/app/reddit_actions.py
+++ b/app/reddit_actions.py
@@ -36,6 +36,7 @@ def submit_transcription(
     transcription_obj.save()
 
 
+@send_to_worker
 def edit_transcription(
     request: HttpRequest, transcription_obj: Transcription, submission_obj: Submission
 ) -> None:

--- a/blossom/templates/app/transcribing.html
+++ b/blossom/templates/app/transcribing.html
@@ -206,7 +206,7 @@
         {% if not transcription %}
             simplemde.value("Put your transcription here!");
         {% else %}
-            simplemde.value(`{{ transcription }}`)
+            simplemde.value(`{{ transcription|safe }}`)
         {% endif %}
 
         fetch('{% url "subredditjsonproxy" %}?s={{ submission.get_subreddit_name }}')


### PR DESCRIPTION
Relevant issue: #275 

## Description:

All transcription text is automatically escaped for security reasons, but because it's being dropped right into SimpleMDE then we can mark it as safe and let normal HTML characters (`< > & %` to name a few) render as expected.

## Screenshots:

![image](https://user-images.githubusercontent.com/5179553/147434599-4b4798e1-3d73-472e-bc67-df5a8deadd7f.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
