### PR TITLE
Fix markdown editor not clearing content for new transcription

### DIFF
--- a/blossom/templates/app/transcribing.html
+++ b/blossom/templates/app/transcribing.html
@@ -207,6 +207,8 @@
 
         {% if transcription %}
             simplemde.value(`{{ transcription|safe }}`)
+        {% else %}
+            simplemde.value("")
         {% endif %}
 
         fetch('{% url "subredditjsonproxy" %}?s={{ submission.get_subreddit_name }}')


### PR DESCRIPTION
Relevant issue: #279 

## Description:

The markdown editor for the transcription app didn't clear properly when starting a new transcription.
Instead, it included the text of the previous transcription.

This PR sets the default content to be empty, hopefully resolving this issue.

⚠️ I haven't tested this at all, so I have no idea if it actually works ⚠️ 

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
