### PR TITLE
Add button to app to report posts without claiming them

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     ),
     path("accept_coc/", views.accept_coc, name="accept_coc"),
     path("unclaim/<int:submission_id>/", views.unclaim_submission, name="app_unclaim"),
+    path("report/<int:submission_id>/", views.report_submission, name="app_report"),
     path(
         "previous_transcriptions/",
         views.view_previous_transcriptions,

--- a/app/views.py
+++ b/app/views.py
@@ -583,3 +583,12 @@ def unclaim_submission(
     flair_post(submission_obj, Flair.unclaimed)
     ask_about_removing_post(request, submission_obj)
     return redirect("choose_transcription")
+
+
+@login_required
+@require_coc
+def report_submission(request: HttpRequest, submission_id: int) -> HttpResponseRedirect:
+    """Process reports without unclaiming that originate from the web app side."""
+    submission_obj = Submission.objects.get(id=submission_id)
+    ask_about_removing_post(request, submission_obj)
+    return redirect("choose_transcription")

--- a/blossom/templates/app/partials/transcription_card.partial
+++ b/blossom/templates/app/partials/transcription_card.partial
@@ -26,15 +26,19 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="row mt-3">
-                <div class="col-0 col-sm-3"></div>
-                <div class="col-12 col-sm-6">
+            <div class="row mt-3 gx-5">
+                <div class="col">
                     <div class="d-grid gap-2">
                         <a href="{% url 'transcribe_submission' item.id %}" type="submit"
                            class="btn btn-success">Transcribe!</a>
                     </div>
                 </div>
-                <div class="col-0 col-sm-3"></div>
+                <div class="col">
+                    <div class="d-grid gap-2">
+                        <a href="#" type="submit"
+                           class="btn btn-outline-danger">Report</a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/blossom/templates/app/partials/transcription_card.partial
+++ b/blossom/templates/app/partials/transcription_card.partial
@@ -35,11 +35,47 @@
                 </div>
                 <div class="col">
                     <div class="d-grid gap-2">
-                        <a href="#" type="submit"
-                           class="btn btn-outline-danger">Report</a>
+                        <button type="button"
+                                class="btn btn-outline-danger"
+                                data-bs-toggle="modal"
+                                data-bs-target="#reportOptionsModal"
+                        >
+                            Report
+                        </button>
                     </div>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+<div class="modal fade" id="reportOptionsModal" tabindex="-1" aria-labelledby="optionsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="optionsModalLabel">Report Options</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Please choose a reason for reporting this post:
+            </div>
+            <div class="d-grid gap-2 mx-2 mb-2">
+                <a href="{% url 'app_report' submission.id %}?reason=rules" class="btn btn-outline-danger">
+                    Post breaks rules
+                </a>
+                <a href="{% url 'app_report' submission.id %}?reason=removed" class="btn btn-outline-danger">
+                    Post was removed
+                </a>
+                <a href="{% url 'app_report' submission.id %}?reason=op_transcribed"
+                   class="btn btn-outline-danger">
+                    OP already transcribed it
+                </a>
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/blossom/templates/app/partials/transcription_card.partial
+++ b/blossom/templates/app/partials/transcription_card.partial
@@ -38,7 +38,7 @@
                         <button type="button"
                                 class="btn btn-outline-danger"
                                 data-bs-toggle="modal"
-                                data-bs-target="#reportOptionsModal"
+                                data-bs-target="#reportOptionsModal-{{ item.id }}"
                         >
                             Report
                         </button>
@@ -49,7 +49,7 @@
     </div>
 </div>
 
-<div class="modal fade" id="reportOptionsModal" tabindex="-1" aria-labelledby="optionsModalLabel" aria-hidden="true">
+<div class="modal fade" id="reportOptionsModal-{{ item.id }}" tabindex="-1" aria-labelledby="optionsModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
@@ -60,13 +60,13 @@
                 Please choose a reason for reporting this post:
             </div>
             <div class="d-grid gap-2 mx-2 mb-2">
-                <a href="{% url 'app_report' submission.id %}?reason=rules" class="btn btn-outline-danger">
+                <a href="{% url 'app_report' item.id %}?reason=rules" class="btn btn-outline-danger">
                     Post breaks rules
                 </a>
-                <a href="{% url 'app_report' submission.id %}?reason=removed" class="btn btn-outline-danger">
+                <a href="{% url 'app_report' item.id %}?reason=removed" class="btn btn-outline-danger">
                     Post was removed
                 </a>
-                <a href="{% url 'app_report' submission.id %}?reason=op_transcribed"
+                <a href="{% url 'app_report' item.id %}?reason=op_transcribed"
                    class="btn btn-outline-danger">
                     OP already transcribed it
                 </a>

--- a/blossom/templates/app/partials/transcription_card.partial
+++ b/blossom/templates/app/partials/transcription_card.partial
@@ -26,14 +26,14 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="row mt-3 gx-5">
-                <div class="col">
+            <div class="row mt-3 gx-3 gy-2 justify-content-center">
+                <div class="col-md-7">
                     <div class="d-grid gap-2">
                         <a href="{% url 'transcribe_submission' item.id %}" type="submit"
                            class="btn btn-success">Transcribe!</a>
                     </div>
                 </div>
-                <div class="col">
+                <div class="col-md-4">
                     <div class="d-grid gap-2">
                         <button type="button"
                                 class="btn btn-outline-danger"

--- a/blossom/templates/app/partials/transcription_card.partial
+++ b/blossom/templates/app/partials/transcription_card.partial
@@ -27,7 +27,7 @@
                 </div>
             </div>
             <div class="row mt-3 gx-3 gy-2 justify-content-center">
-                <div class="col-md-7">
+                <div class="col-md-8">
                     <div class="d-grid gap-2">
                         <a href="{% url 'transcribe_submission' item.id %}" type="submit"
                            class="btn btn-success">Transcribe!</a>


### PR DESCRIPTION
Relevant issue: Close #259

## Description:

This adds a second button to the transcription cards which allows the users to report a post without claiming it first.

## Screenshots:

![The new transcription card with an additional "Report" button.](https://user-images.githubusercontent.com/13908946/147564912-7afdae49-0f06-4457-89ee-1a94d5861441.png)

![The modal that opens when you click "Report". It allows you to select the report reason, namely that the post breaks the rules, that the post was removed or that OP already transcribed the post.](https://user-images.githubusercontent.com/13908946/147564945-d7ef47ed-eec2-47bd-9a3c-765ef5ef1752.png)


## Testing Instructions:

Go to https://thetranscription.app/app/ and you should see a "Report" button for each transcription card.
When you click the button, it should show a modal to choose the report reason.
When you click the report reason it should send the report to Slack and then reroll the posts.

## Future Work

Instead of rerolling all posts, it should only reroll the post you reported. That way, if you see multiple rule violations you could report all of them.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
