### PR TITLE
Add additional reroll button and in-progress transcriptions to top of page

### DIFF
--- a/blossom/templates/app/choose_transcription.html
+++ b/blossom/templates/app/choose_transcription.html
@@ -42,7 +42,18 @@
     </style>
 
     {% if options %}
-        <h1>Choose Post to Transcribe</h1>
+        <div class="container">
+            <div class="row">
+                <h1 class="col-md">Choose Post to Transcribe</h1>
+                <div class="col">
+                    <div class="d-grid gap-2">
+                        <a href="{% url 'choose_transcription' %}"
+                           class="btn btn-outline-primary"
+                           title="Get a new set of posts to choose from">Reroll!</a>
+                    </div>
+                </div>
+            </div>
+        </div>
     {% endif %}
     {% if messages %}
         {% for message in messages %}
@@ -72,33 +83,12 @@
                     {% endfor %}
                 </div>
             {% endif %}
-            Pick one of the {{ options|length|apnumber }} options below to get started!
-
-            <div class="row mt-3">
-                <div class="col-0 col-sm-3"></div>
-                <div class="col-12 col-sm-6">
-                    <div class="d-grid gap-2">
-                        <a href="{% url 'choose_transcription' %}" class="btn btn-outline-primary">Reroll!</a>
-                    </div>
-                </div>
-                <div class="col-0 col-sm-3"></div>
-            </div>
             <div class="container">
                 <div class="row">
                     {% for option in options %}
                         {% include 'app/partials/transcription_card.partial' with item=option %}
                     {% endfor %}
                 </div>
-            </div>
-            <div class="text-muted mt-4 text-center">Don't like these options? Just reroll!</div>
-            <div class="row mt-3 mb-5">
-                <div class="col-0 col-sm-3"></div>
-                <div class="col-12 col-sm-6">
-                    <div class="d-grid gap-2">
-                        <a href="{% url 'choose_transcription' %}" class="btn btn-outline-primary">Reroll!</a>
-                    </div>
-                </div>
-                <div class="col-0 col-sm-3"></div>
             </div>
         {% endif %}
     </div>

--- a/blossom/templates/app/choose_transcription.html
+++ b/blossom/templates/app/choose_transcription.html
@@ -66,13 +66,15 @@
         {% else %}
             {% if claimed_submissions %}
                 <h2>Transcriptions You're Working On</h2>
-                <div class="row">
+                <div class="row justify-content-center">
                     {% for claimed in claimed_submissions %}
                         {% include 'app/partials/claimed_transcription.partial' with item=claimed %}
                     {% endfor %}
                 </div>
             {% endif %}
-            <div class="row mt-3 mb-5">
+            Pick one of the {{ options|length|apnumber }} options below to get started!
+
+            <div class="row mt-3">
                 <div class="col-0 col-sm-3"></div>
                 <div class="col-12 col-sm-6">
                     <div class="d-grid gap-2">
@@ -80,8 +82,6 @@
                     </div>
                 </div>
                 <div class="col-0 col-sm-3"></div>
-            </div>
-            Pick one of the {{ options|length|apnumber }} options below to get started!
             </div>
             <div class="container">
                 <div class="row">
@@ -101,6 +101,7 @@
                 <div class="col-0 col-sm-3"></div>
             </div>
         {% endif %}
+    </div>
 {% endblock %}
 
 {% block scripts %}

--- a/blossom/templates/app/choose_transcription.html
+++ b/blossom/templates/app/choose_transcription.html
@@ -64,6 +64,23 @@
         {% elif not options %}
             {% include 'app/partials/cleared_queue.partial' %}
         {% else %}
+            {% if claimed_submissions %}
+                <h2>Transcriptions You're Working On</h2>
+                <div class="row">
+                    {% for claimed in claimed_submissions %}
+                        {% include 'app/partials/claimed_transcription.partial' with item=claimed %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+            <div class="row mt-3 mb-5">
+                <div class="col-0 col-sm-3"></div>
+                <div class="col-12 col-sm-6">
+                    <div class="d-grid gap-2">
+                        <a href="{% url 'choose_transcription' %}" class="btn btn-outline-primary">Reroll!</a>
+                    </div>
+                </div>
+                <div class="col-0 col-sm-3"></div>
+            </div>
             Pick one of the {{ options|length|apnumber }} options below to get started!
             </div>
             <div class="container">
@@ -83,14 +100,6 @@
                 </div>
                 <div class="col-0 col-sm-3"></div>
             </div>
-            {% if claimed_submissions %}
-                <h2>Transcriptions You're Working On</h2>
-                <div class="row">
-                    {% for claimed in claimed_submissions %}
-                        {% include 'app/partials/claimed_transcription.partial' with item=claimed %}
-                    {% endfor %}
-                </div>
-            {% endif %}
         {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Relevant issue: Closes #255

## Description:

This PR restructures the transcription choice page:
- Moves the list of in-progress transcriptions to the very top for better visibility
- Moves the "Reroll!" button to the top so that it stays at the same place after refreshing
- Removes some verbose text to save space

![The reworked transcription choice page. The reroll button has been moved to the top, in the same line as the heading. The explanatory text has been removed as it should be clear from the buttons alone.](https://user-images.githubusercontent.com/13908946/147587689-27def066-f16b-4a0c-a1e8-2361d652c9ed.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
