### PR TITLE
Hide reroll button in edit mode

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -266,6 +266,7 @@ class EditSubmissionTranscription(
         context = get_additional_context({"fullwidth_view": True})
         context.update({"submission": submission})
         context.update({"transcription_templates": get_and_format_templates()})
+        context.update({"edit_mode": True})
         context = update_context_with_proxy_data(submission, context)
 
         if s_id := request.session.get("submission_id"):
@@ -378,6 +379,7 @@ class TranscribeSubmission(CSRFExemptMixin, LoginRequiredMixin, RequireCoCMixin,
 
         context = get_additional_context({"fullwidth_view": True})
         context.update({"submission": submission})
+        context.update({"edit_mode": False})
 
         context.update({"transcription_templates": get_and_format_templates()})
 

--- a/blossom/templates/app/transcribing.html
+++ b/blossom/templates/app/transcribing.html
@@ -96,7 +96,7 @@
                         </div>
                     </div>
 
-                    {% if edit_mode %}
+                    {% if not edit_mode %}
                         <div class="col-12 col-lg-3 mb-3">
                             <div class="d-grid gap-2">
                                 <button type="button"

--- a/blossom/templates/app/transcribing.html
+++ b/blossom/templates/app/transcribing.html
@@ -95,17 +95,20 @@
                             </button>
                         </div>
                     </div>
-                    <div class="col-12 col-lg-3 mb-3">
-                        <div class="d-grid gap-2">
-                            <button type="button"
-                                    class="btn btn-outline-danger"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="#optionsModal"
-                            >
-                                Reroll
-                            </button>
+
+                    {% if edit_mode %}
+                        <div class="col-12 col-lg-3 mb-3">
+                            <div class="d-grid gap-2">
+                                <button type="button"
+                                        class="btn btn-outline-danger"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#optionsModal"
+                                >
+                                    Reroll
+                                </button>
+                            </div>
                         </div>
-                    </div>
+                    {% endif %}
                     <div class="col-0 col-sm-1"></div>
                 </div>
             </form>

--- a/blossom/templates/app/transcribing.html
+++ b/blossom/templates/app/transcribing.html
@@ -83,9 +83,8 @@
                         it for you!
                     </div>
                 </div>
-                <div class="row mt-3">
-                    <div class="col-0 col-lg-1"></div>
-                    <div class="col-12 col-lg-7 mb-2">
+                <div class="row mt-3 mx-2 justify-content-center">
+                    <div class="col-lg-7 mb-2">
                         <div class="d-grid gap-2">
                             <button
                                     class="btn btn-primary"
@@ -97,7 +96,7 @@
                     </div>
 
                     {% if not edit_mode %}
-                        <div class="col-12 col-lg-3 mb-3">
+                        <div class="col-lg-3 mb-3">
                             <div class="d-grid gap-2">
                                 <button type="button"
                                         class="btn btn-outline-danger"
@@ -109,7 +108,6 @@
                             </div>
                         </div>
                     {% endif %}
-                    <div class="col-0 col-sm-1"></div>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
Relevant issue: Closes #274

## Description:

This hides the "Reroll" button when editing a transcription.

## Screenshot:

![Screenshot of the transcription edit mode. It now hides the reroll button to prevent unwanted behavior.](https://user-images.githubusercontent.com/13908946/147568193-9ec37961-2210-40fa-8fd0-1e20e23c9241.png)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
