### PR TITLE
Handle imgur posts that are not direct links

### DIFF
--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -258,9 +258,10 @@ class TestTranscribeSubmission:
         client, _, user = setup_user_client(client)
         add_social_auth_to_user(user)
 
+        # Imgur direct link
         submission = create_submission(
             original_id=int(random.random() * 1000),
-            content_url="http://imgur.com/aaa",
+            content_url="http://imgur.com/aaa.png",
             title="a",
         )
 
@@ -269,8 +270,20 @@ class TestTranscribeSubmission:
         )
 
         assert "imgur_content_url" in response.context
-        assert response.context["imgur_content_url"] == "aaa"
+        assert response.context["imgur_content_url"] == "aaa.png"
 
+        # Imgur post link
+        submission.claimed_by = None
+        submission.content_url = "http://imgur.com/aaa"
+        submission.save()
+
+        response = client.get(
+            reverse("transcribe_submission", kwargs={"submission_id": submission.id})
+        )
+        assert "imgur_content_url" in response.context
+        assert response.context["imgur_content_url"] == "aaa.jpg"
+
+        # Reddit link
         submission.claimed_by = None
         submission.content_url = "i.redd.it/bbb"
         submission.save()

--- a/app/views.py
+++ b/app/views.py
@@ -195,7 +195,13 @@ def update_context_with_proxy_data(submission: Submission, context: dict) -> dic
         # through the proxy for OpenSeaDragon
         context.update({"ireddit_content_url": submission.content_url.split("/")[-1]})
     elif "imgur.com" in submission.content_url:
-        context.update({"imgur_content_url": submission.content_url.split("/")[-1]})
+        imgur_content_url = submission.content_url.split("/")[-1]
+        # Check if the URL links to the imgur post instead of directly to the image
+        # Kinda dirty, but this way we can account for all image formats
+        if "." not in imgur_content_url:
+            imgur_content_url += ".jpg"
+
+        context.update({"imgur_content_url": imgur_content_url})
     return context
 
 


### PR DESCRIPTION
Relevant issue: Closes #246

## Description:

This handles Imgur links like https://imgur.com/OhUY1rS which don't link to the image directly.
The bot will try to slap `.jpg` at the end to properly render the image.

This does **not** fix the display of the images in the transcription choice page. Those are more annoying to handle.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
