### PR TITLE
Remove submissions on report

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -5,7 +5,7 @@ from api.models import Submission, Transcription
 
 
 class SubmissionAdmin(admin.ModelAdmin):
-    search_fields = ("original_id", "title", "url", "tor_url")
+    search_fields = ("id", "original_id", "title", "url", "tor_url")
 
 
 # Register your models here.

--- a/api/views/slack_helpers.py
+++ b/api/views/slack_helpers.py
@@ -126,7 +126,10 @@ def process_submission_update(data: dict) -> None:
     # https://app.slack.com/block-kit-builder/
     value = data["actions"][0].get("value").split("_")
     blocks = data["message"]["blocks"]
+    submission_obj = Submission.objects.get(id=int(value[2]))
     if value[0] == "keep":
+        submission_obj.removed_from_queue = False
+        submission_obj.save(skip_extras=True)
         blocks[-1] = {
             "type": "section",
             "text": {
@@ -135,10 +138,9 @@ def process_submission_update(data: dict) -> None:
             },
         }
     else:
-        submission_obj = Submission.objects.get(id=int(value[2]))
-        submission_obj.removed_from_queue = True
-        submission_obj.save(skip_extras=True)
-        # pull the post out of the reddit queue
+        # The submission was removed temporarily from the app queue when it was reported,
+        # so we don't have to do anything else on the app side. Now that it's been
+        # verified, go ahead and nuke it from Reddit's side as well.
         remove_post(submission_obj)
         blocks[-1] = {
             "type": "section",

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -198,6 +198,26 @@ class TestChooseSubmission:
         assert len(response.context["options"]) == 0
         assert "show_error_page" not in response.context
 
+    def test_reported_post_is_removed(self, client: Client) -> None:
+        """Verify that a reported post is not brought back to the page."""
+        client, _, user = setup_user_client(client)
+        add_social_auth_to_user(user)
+
+        submission = create_submission(
+            original_id=int(random.random() * 1000),
+            title="a",
+            content_url="http://imgur.com",
+        )
+
+        response = client.get(reverse("choose_transcription"))
+
+        assert submission in response.context["options"]
+
+        # Now we'll report it and verify that it's not rolled anymore
+        client.get(reverse("app_report", kwargs={"submission_id": submission.id}))
+        response = client.get(reverse("choose_transcription"))
+        assert submission not in response.context["options"]
+
 
 class TestTranscribeSubmission:
     def test_load_page(self, client: Client) -> None:


### PR DESCRIPTION
Relevant issue: #258

## Description:

Something that was brought up in Discord is that reported posts stay in the queue, and because we're not tied to Reddit anymore, we can remove these now as they come in and avoid the unfortunate situation that happened earlier with a volunteer reporting a post and then rerolling it multiple times. This PR reworks the logic of the report flow to automatically remove a post pending the response from the Slack ping, which can optionally reinstate it. Also includes some very small fixes I noticed while debugging this.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
