### PR TITLE
Get slack channels from environment variables

### DIFF
--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -43,6 +43,7 @@ from api.pagination import StandardResultsSetPagination
 from api.serializers import SubmissionSerializer
 from api.views.slack_helpers import _send_transcription_to_slack
 from api.views.slack_helpers import client as slack
+from api.views.slack_helpers import send_slack_message
 from api.views.volunteer import VolunteerViewSet
 from authentication.models import BlossomUser
 
@@ -69,7 +70,7 @@ def _check_for_rank_up(user: BlossomUser, submission: Submission = None) -> None
             f" {submission.tor_url}"
         )
         try:
-            slack.chat_postMessage(channel="#new_volunteers_meta", text=msg)
+            send_slack_message(channel="RANK_UP", text=msg)
         except:  # noqa
             logger.warning(f"Cannot post message to slack. Msg: {msg}")
             pass

--- a/app/views.py
+++ b/app/views.py
@@ -24,7 +24,7 @@ from django.views.generic import View
 from rest_framework import status
 
 from api.models import Source, Submission, Transcription
-from api.views.slack_helpers import client
+from api.views.slack_helpers import send_slack_message
 from api.views.submission import SubmissionViewSet
 from app.permissions import RequireCoCMixin, require_coc, require_reddit_auth
 from app.reddit_actions import (
@@ -548,7 +548,7 @@ def ask_about_removing_post(request: HttpRequest, submission: Submission) -> Non
         submission.id
     )
     log.info(f"Sending message to Slack to ask about removing {submission.id}")
-    client.chat_postMessage(channel="reported_posts", blocks=blocks)
+    send_slack_message(channel_key="REPORTED_POST", blocks=blocks)
 
 
 @login_required


### PR DESCRIPTION
Relevant issue: Closes #309

## Description:

This gets the Slack channels from the environment variables / config files instead of hard-coding them.

Outstanding issues: Fixing the tests

On production, the following variables have to be defined in the config:
```
SLACK_GITHUB_SPONSORS_CHANNEL = "..."
SLACK_TRANSCRIPTION_CHECK_CHANNEL = "..."
SLACK_REPORTED_POST_CHANNEL = "..."
SLACK_RANK_UP_CHANNEL = "..."
```

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
