### PR TITLE
Expose `removed_from_queue` to API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -73,6 +73,7 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
             "archived",
             "cannot_ocr",
             "redis_id",
+            "removed_from_queue",
         )
         # TODO: Omitting the below line while adding `transcription_set` makes
         # a call to a single submission created with the test data set take

--- a/api/tests/submissions/test_submission_get.py
+++ b/api/tests/submissions/test_submission_get.py
@@ -304,3 +304,28 @@ class TestSubmissionGet:
         )
         assert result.status_code == status.HTTP_200_OK
         assert len(result.json()["results"]) == result_count
+
+    @pytest.mark.parametrize(
+        "filter_str,result_count",
+        [("removed_from_queue=true", 1), ("removed_from_queue=false", 1), ("", 2)],
+    )
+    def test_list_with_removed_filter(
+        self, client: Client, filter_str: str, result_count: int
+    ) -> None:
+        """Verify that submissions can be filtered by their removal status."""
+        client, headers, user = setup_user_client(client, id=123)
+
+        create_submission(
+            id=1, removed_from_queue=True,
+        )
+        create_submission(
+            id=2, removed_from_queue=False,
+        )
+
+        result = client.get(
+            reverse("submission-list") + f"?{filter_str}",
+            content_type="application/json",
+            **headers,
+        )
+        assert result.status_code == status.HTTP_200_OK
+        assert len(result.json()["results"]) == result_count

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -144,6 +144,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         "archived": ["exact"],
         "content_url": ["exact", "isnull"],
         "redis_id": ["exact", "isnull"],
+        "removed_from_queue": ["exact"],
     }
     ordering_fields = [
         "id",


### PR DESCRIPTION
Relevant issue: Closes #312

## Description:

This PR adds the `removed_from_queue` field to the submission query parameters and the serializer so that clients can use it.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
