### PR TITLE
Add `submission/remove` endpoint

### DIFF
--- a/api/tests/submissions/test_submission_remove.py
+++ b/api/tests/submissions/test_submission_remove.py
@@ -1,0 +1,95 @@
+import json
+
+from django.test import Client
+from django.urls import reverse
+from rest_framework import status
+
+from utils.test_helpers import create_submission, setup_user_client
+
+
+class TestSubmissionRemove:
+    """Tests validating the behavior of the Submission removal process."""
+
+    def test_remove_no_params(self, client: Client) -> None:
+        """Verify that removing a submission works without parameters."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3)
+        assert not submission.removed_from_queue
+
+        data = {}
+
+        result = client.patch(
+            reverse("submission-remove", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_201_CREATED
+        assert submission.removed_from_queue
+
+    def test_remove_no_change(self, client: Client) -> None:
+        """Verify that removing a submission works without parameters."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3, removed_from_queue=True)
+        assert submission.removed_from_queue
+
+        data = {}
+
+        result = client.patch(
+            reverse("submission-remove", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_201_CREATED
+        assert submission.removed_from_queue
+
+    def test_remove_param_false(self, client: Client) -> None:
+        """Verify that restoring submissions works correctly."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3, removed_from_queue=True)
+        assert submission.removed_from_queue
+
+        data = {"removed_from_queue": False}
+
+        result = client.patch(
+            reverse("submission-remove", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_201_CREATED
+        assert not submission.removed_from_queue
+
+    def test_remove_param_true(self, client: Client) -> None:
+        """Verify that removing a submission works without parameters."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3)
+        assert not submission.removed_from_queue
+
+        data = {"removed_from_queue": True}
+
+        result = client.patch(
+            reverse("submission-remove", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_201_CREATED
+        assert submission.removed_from_queue

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -848,11 +848,8 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             404: "Submission not found.",
         },
     )
-    @validate_request(data_params={"removed_from_queue"})
     @action(detail=True, methods=["patch"])
-    def remove(
-        self, request: Request, pk: int, removed_from_queue: bool = True
-    ) -> Response:
+    def remove(self, request: Request, pk: int) -> Response:
         """
         Remove the submission from the queue.
 
@@ -860,6 +857,8 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         in the body of the request.
         """
         submission = get_object_or_404(Submission, id=pk)
+
+        removed_from_queue = request.data.get("removed_from_queue", True)
 
         submission.removed_from_queue = removed_from_queue
         submission.save()

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -838,6 +838,36 @@ class SubmissionViewSet(viewsets.ModelViewSet):
 
         return Response(data)
 
+    @csrf_exempt
+    @swagger_auto_schema(
+        request_body=Schema(
+            type="object", properties={"removed_from_queue": Schema(type="bool")}
+        ),
+        responses={
+            201: DocResponse("Successful removal", schema=serializer_class),
+            404: "Submission not found.",
+        },
+    )
+    @validate_request(data_params={"removed_from_queue"})
+    @action(detail=True, methods=["patch"])
+    def remove(
+        self, request: Request, pk: int, removed_from_queue: bool = True
+    ) -> Response:
+        """
+        Remove the submission from the queue.
+
+        It is also possible to revert the removal by setting removed_from_queue to false
+        in the body of the request.
+        """
+        submission = get_object_or_404(Submission, id=pk)
+
+        submission.removed_from_queue = removed_from_queue
+        submission.save()
+        return Response(
+            status=status.HTTP_201_CREATED,
+            data=self.serializer_class(submission, context={"request": request}).data,
+        )
+
 
 def _is_returning_transcriber(volunteer: BlossomUser) -> bool:
     """Determine if the transcriber is returning.


### PR DESCRIPTION
Relevant issue: Closes #315 

## Description:

This adds a new endpoint that allows us to remove (and restore) posts from the queue.
This is necessary to synchronize the Blossom and Reddit queues.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
