### PR TITLE
Run CI tests in parallel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,5 +29,5 @@ jobs:
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_SECRET }}
       run: |
-        poetry run pytest
+        poetry run pytest --workers=auto
         poetry run coveralls


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This is an attempt to run the CI tests in parallel, via the `pytest --workers=auto` option.
This option seems to break on some systems, so we'll have to see if it actually works.

If it does, it could significantly speed up our pipeline though.

## Checklist:

- [ ] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
