### PR TITLE
Fix saving of the Slack channel ID when reporting a post

### DIFF
--- a/api/views/slack_helpers.py
+++ b/api/views/slack_helpers.py
@@ -575,7 +575,7 @@ def ask_about_removing_post(submission: Submission, reason: str) -> None:
         )
         return
 
-    # TODO: Does this actually work?
-    submission.report_slack_channel_id = response["channel"]["id"]
+    # See https://api.slack.com/methods/chat.postMessage
+    submission.report_slack_channel_id = response["channel"]
     submission.report_slack_message_ts = response["message"]["ts"]
     submission.save()

--- a/api/views/slack_helpers.py
+++ b/api/views/slack_helpers.py
@@ -145,10 +145,14 @@ def process_submission_update(data: dict) -> None:
             },
         }
     else:
-        # The submission was removed temporarily from the app queue when it was reported,
-        # so we don't have to do anything else on the app side. Now that it's been
-        # verified, go ahead and nuke it from Reddit's side as well.
+        # Remove the post from Reddit
         remove_post(submission_obj)
+        # Make sure the submission is marked as removed
+        # If reported on the app side this already happened, but not for
+        # reports from Reddit
+        submission_obj.removed_from_queue = True
+        submission_obj.save(skip_extras=True)
+
         blocks[-1] = {
             "type": "section",
             "text": {

--- a/app/tests/test_misc.py
+++ b/app/tests/test_misc.py
@@ -20,10 +20,26 @@ def test_ask_about_removing_post() -> None:
     """Verify that block messages are handled appropriately."""
     # Mock the Slack client to catch the sent messages by the function under test.
     mock = MagicMock()
+    # From https://api.slack.com/methods/chat.postMessage
     mock.return_value = {
         "ok": True,
-        "message": {"ts": "12345"},
-        "channel": {"id": "6789"},
+        "channel": "C1H9RESGL",
+        "ts": "1503435956.000247",
+        "message": {
+            "text": "Here's a message for you",
+            "username": "ecto1",
+            "bot_id": "B19LU7CSY",
+            "attachments": [
+                {
+                    "text": "This is an attachment",
+                    "id": 1,
+                    "fallback": "This is an attachment's fallback",
+                }
+            ],
+            "type": "message",
+            "subtype": "bot_message",
+            "ts": "1503435956.000247",
+        },
     }
     slack_client.chat_postMessage = mock
 
@@ -34,8 +50,8 @@ def test_ask_about_removing_post() -> None:
     ask_about_removing_post(submission, "asdf", worker_test_mode=True)
     submission.refresh_from_db()
 
-    assert submission.report_slack_channel_id == "6789"
-    assert submission.report_slack_message_ts == "12345"
+    assert submission.report_slack_channel_id == "C1H9RESGL"
+    assert submission.report_slack_message_ts == "1503435956.000247"
     blocks = mock.call_args[1]["blocks"]
     assert "asdf" in blocks[2]["text"]["text"]
     assert "submission_3" in blocks[-1]["elements"][0]["value"]


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Saving the channel ID of a Slack report message failed, because I misunderstood the response by the Slack API.
For future reference: https://api.slack.com/methods/chat.postMessage

This also fixes submissions not being marked as removed after being reported on Reddit.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
