### PR TITLE
move pytest information into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,7 @@ exclude = '''
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "blossom.settings.testing"
+python_files = "tests.py test_*.py *_tests.py"
+addopts = "--nomigrations --cov=. --cov-report=html --cov-report=term:skip-covered -p no:warnings"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = blossom.settings.testing
-python_files = tests.py test_*.py *_tests.py
-addopts = --nomigrations --cov=. --cov-report=html --cov-report=term:skip-covered -p no:warnings


### PR DESCRIPTION
Relevant issue: https://github.com/GrafeasGroup/blossom/issues/323
## Description:

Move the pytest ini information into the pyproject.toml file and also extend one test for greater coverage.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
