### PR TITLE
Hotfix: Fix import of Slack API

### DIFF
--- a/api/slack/__init__.py
+++ b/api/slack/__init__.py
@@ -3,13 +3,13 @@ import os
 from unittest import mock
 
 from django.conf import settings
+from slack import WebClient
 
-from api import slack
 from blossom.errors import ConfigurationError
 
 if settings.ENABLE_SLACK is True:
     try:
-        client = slack.WebClient(token=os.environ["SLACK_API_KEY"])  # pragma: no cover
+        client = WebClient(token=os.environ["SLACK_API_KEY"])  # pragma: no cover
     except KeyError:
         raise ConfigurationError(
             "ENABLE_SLACK is set to True, but no API key was found. Set the"


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This PR attempts to fix a wrong import of the Slack API which resulted in the Blossom deployment failing.

PyCharm warns with "Package containing module 'slack' is not listed in the project requirements" for the import so I'm not 100% sure if this fixes the problem.

## Checklist:

- [ ] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
