### PR TITLE
Add watchlist Slack command

### DIFF
--- a/api/slack/commands.py
+++ b/api/slack/commands.py
@@ -241,26 +241,29 @@ def watchlist_cmd(channel: str, message: str) -> None:
             if usr.overwrite_check_percentage == last_percentage:
                 response_msg += " " * 6 + f"u/{usr.username}\n"
             else:
-                response_msg += "*{}*: u/{}".format(
-                    f"{usr.overwrite_check_percentage:.0%}".rjust(4, ""), usr.username
+                response_msg += "{}: u/{}\n".format(
+                    f"{usr.overwrite_check_percentage:.0%}".rjust(4, " "), usr.username
                 )
                 last_percentage = usr.overwrite_check_percentage
     elif sorting == "alphabetical":
         # Sort the users alphabetically
-        watched_users.sort(key=lambda u: u.username.casefold(), reverse=True)
+        watched_users.sort(key=lambda u: u.username.casefold())
 
         for usr in watched_users:
-            response_msg += "u/{} ({:.0%})".format(
+            response_msg += "u/{} ({:.0%})\n".format(
                 usr.username, usr.overwrite_check_percentage
             )
     else:
+        # Invalid sorting
         response_msg = (
             f"Invalid sorting '{sorting}'. "
             "Use either 'percentage' or 'alphabetical'."
         )
+        client.chat_postMessage(channel=channel, text=response_msg)
+        return
 
     response_msg += "```"
-    client.chat_postMessage(channel=channel, text=response_msg)
+    client.chat_postMessage(channel=channel, text=response_msg.strip())
 
 
 def dadjoke_cmd(channel: str, message: str, use_api: bool = True) -> None:

--- a/api/tests/test_slack.py
+++ b/api/tests/test_slack.py
@@ -19,6 +19,7 @@ from api.slack.commands import (
     reset_cmd,
     unwatch_cmd,
     watch_cmd,
+    watchlist_cmd,
 )
 from api.slack.events import is_valid_github_request
 from api.slack.utils import dict_to_table
@@ -428,6 +429,75 @@ def test_process_unwatch() -> None:
 
     assert test_user.overwrite_check_percentage is None
     assert slack_client.chat_postMessage.call_args[1]["text"] == expected_message
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        (
+            "watchlist",
+            """**List of all watched users:**
+
+```
+100%: u/aaa
+      u/bbb
+ 70%: u/fff
+ 60%: u/ccc
+      u/eee
+ 30%: u/ddd
+```""",
+        ),
+        (
+            "watchlist percentage",
+            """**List of all watched users:**
+
+```
+100%: u/aaa
+      u/bbb
+ 70%: u/fff
+ 60%: u/ccc
+      u/eee
+ 30%: u/ddd
+```""",
+        ),
+        (
+            "watchlist alphabetical",
+            """**List of all watched users:**
+
+```
+u/aaa (100%)
+u/bbb (100%)
+u/ccc (60%)
+u/ddd (30%)
+u/eee (60%)
+u/fff (70%)
+```""",
+        ),
+        (
+            "watchlist asdf",
+            "Invalid sorting 'asdf'. Use either 'percentage' or 'alphabetical'.",
+        ),
+    ],
+)
+def test_process_watchlist(message: str, expected: str) -> None:
+    """Test watchlist functionality."""
+    slack_client.chat_postMessage = MagicMock()
+
+    # Test users
+    # The order is scrambled intentionally to test sorting
+    create_user(id=888, username="hhh", overwrite_check_percentage=None)
+    create_user(id=111, username="aaa", overwrite_check_percentage=1.0)
+    create_user(id=444, username="ddd", overwrite_check_percentage=0.3)
+    create_user(id=222, username="bbb", overwrite_check_percentage=1.0)
+    create_user(id=777, username="ggg", overwrite_check_percentage=None)
+    create_user(id=555, username="eee", overwrite_check_percentage=0.6)
+    create_user(id=333, username="ccc", overwrite_check_percentage=0.6)
+    create_user(id=666, username="fff", overwrite_check_percentage=0.7)
+
+    # process the message
+    watchlist_cmd("", message)
+    slack_client.chat_postMessage.assert_called_once()
+    assert slack_client.chat_postMessage.call_args[1]["text"] == expected
 
 
 @pytest.mark.parametrize(

--- a/blossom/strings/en_US.toml
+++ b/blossom/strings/en_US.toml
@@ -41,6 +41,7 @@ Blacklist / unblacklist user: `@blossom blacklist {username}`
 Toggle CoC status of user: `@blossom reset {username}`
 Overwrite check percentage: `@blossom watch {username} {percentage}`, where {percentage} is a number between 0 and 100
 Reset check percentage: `@blossom unwatch {username}`
+List all overwritten check percentages: `@blossom watchlist {sorting}`, where {sorting} is either "percentage" (default) or "alphabetical".
 Render this message: `@blossom help`
 """
 


### PR DESCRIPTION
This adds a Slack command to display a list of all users who are currently being watched.

Relevant issue: Closes #336

## Description:

This adds a Slack command to display a list of all currently watched users.

**Usage**: `@Blossom watchlist <sorting>`, where `<sorting>` is either `percentage` (default) or `alphabetical`.
If percentage is used, the users are grouped by their overwritten watch percentage. Otherwise they are sorted alphabetically by username.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
