### PR TITLE
Fix command processing to check for equality

### DIFF
--- a/api/slack/commands.py
+++ b/api/slack/commands.py
@@ -63,10 +63,15 @@ def process_message(data: Dict) -> None:
         "dadjoke": dadjoke_cmd,
     }
 
-    for key in options.keys():
-        if message.startswith(key):
-            options[key](channel, message)
-            return
+    tokens = message.split()
+
+    if len(tokens) > 0:
+        # Find the command corresponding to the message
+        cmd_name = tokens[0].casefold()
+        for key in options.keys():
+            if cmd_name == key:
+                options[key](channel, message)
+                return
 
     # if we fall through here, we got a message that we don't understand.
     client.chat_postMessage(


### PR DESCRIPTION
Relevant issue: N/A

## Description:

The selection on which command was executed used a startswith check. When we have multiple commands that start with the same name, the wrong one might be selected.
In this PR we extract the first token instead and check for equality.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
