### PR TITLE
Fix help and ping commands not taking enough parameters

### DIFF
--- a/api/slack/commands.py
+++ b/api/slack/commands.py
@@ -79,7 +79,7 @@ def process_message(data: Dict) -> None:
     )
 
 
-def help_cmd(channel: str) -> None:
+def help_cmd(channel: str, _message: str) -> None:
     """Post a help message to slack."""
     client.chat_postMessage(channel=channel, text=i18n["slack"]["help_message"])
 
@@ -112,7 +112,7 @@ def info_cmd(channel: str, message: str) -> None:
     client.chat_postMessage(channel=channel, text=msg)
 
 
-def pong_cmd(channel: str) -> None:
+def pong_cmd(channel: str, _message: str) -> None:
     """Respond to pings."""
     client.chat_postMessage(channel=channel, text="PONG")
 


### PR DESCRIPTION
Relevant issue: N/A

## Description:
The help and ping command functions only took the channel parameter because they didn't use the message.
However, the message is still passed by the processing function, so we need to keep it in the function parameters.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
