### PR TITLE
Add /submission/nsfw endpoint

### DIFF
--- a/api/tests/submissions/test_submission_nsfw.py
+++ b/api/tests/submissions/test_submission_nsfw.py
@@ -1,0 +1,95 @@
+import json
+
+from django.test import Client
+from django.urls import reverse
+from rest_framework import status
+
+from utils.test_helpers import create_submission, setup_user_client
+
+
+class TestSubmissionNsfw:
+    """Tests validating the behavior of marking submissions as NSFW."""
+
+    def test_nsfw_no_params(self, client: Client) -> None:
+        """Verify that marking a submission as NSFW works without parameters."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3)
+        assert not submission.nsfw
+
+        data = {}
+
+        result = client.patch(
+            reverse("submission-nsfw", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_200_OK
+        assert submission.nsfw
+
+    def test_nsfw_no_change(self, client: Client) -> None:
+        """Verify that setting a submission NSFW twice doesn't change anything."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3, nsfw=True)
+        assert submission.nsfw
+
+        data = {}
+
+        result = client.patch(
+            reverse("submission-nsfw", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_200_OK
+        assert submission.nsfw
+
+    def test_nsfw_param_false(self, client: Client) -> None:
+        """Verify that marking a submission as NSFW can be reversed."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3, nsfw=True)
+        assert submission.nsfw
+
+        data = {"nsfw": False}
+
+        result = client.patch(
+            reverse("submission-nsfw", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_200_OK
+        assert not submission.nsfw
+
+    def test_remove_param_true(self, client: Client) -> None:
+        """Verify that marking a submission as NSFW works with parameters."""
+        client, headers, user = setup_user_client(client)
+
+        submission = create_submission(id=3)
+        assert not submission.nsfw
+
+        data = {"nsfw": True}
+
+        result = client.patch(
+            reverse("submission-nsfw", args=[submission.id]),
+            json.dumps(data),
+            content_type="application/json",
+            **headers
+        )
+
+        submission.refresh_from_db()
+
+        assert result.status_code == status.HTTP_200_OK
+        assert submission.nsfw

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -909,6 +909,35 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             data=self.serializer_class(submission, context={"request": request}).data,
         )
 
+    @csrf_exempt
+    @swagger_auto_schema(
+        request_body=Schema(type="object", properties={"nsfw": Schema(type="bool")}),
+        responses={
+            200: DocResponse(
+                "Successfully marked as NSFW (or SWF)", schema=serializer_class
+            ),
+            404: "Submission not found.",
+        },
+    )
+    @action(detail=True, methods=["patch"])
+    def nsfw(self, request: Request, pk: int) -> Response:
+        """
+        Mark a submission as NSFW.
+
+        It is also possible to set it back to SFW by setting nsfw to false
+        in the body of the request.
+        """
+        submission = get_object_or_404(Submission, id=pk)
+
+        nsfw = request.data.get("nsfw", True)
+
+        submission.nsfw = nsfw
+        submission.save()
+        return Response(
+            status=status.HTTP_200_OK,
+            data=self.serializer_class(submission, context={"request": request}).data,
+        )
+
 
 def _is_returning_transcriber(volunteer: BlossomUser) -> bool:
     """Determine if the transcriber is returning.


### PR DESCRIPTION
Relevant issue: Closes #346

## Description:

This endpoint allows clients to mark a submission as NSFW or set it back to SFW.
This can be used to sync up the NSFW status with the Reddit queue.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
