### PR TITLE
Change default check percentages as requested by QA

### DIFF
--- a/api/tests/submissions/test_submission_done.py
+++ b/api/tests/submissions/test_submission_done.py
@@ -135,9 +135,10 @@ class TestSubmissionDone:
     @pytest.mark.parametrize(
         "probability,gamma,message,tor_url,trans_url",
         [
-            (1, 3, False, None, None),
-            (0.8, 10, False, None, None),
+            (1, 3, True, None, None),
+            (0.8, 10, True, None, None),
             (0.3999, 50, True, None, None),
+            (0.6, 49, False, None, None),
             (0.7, 51, False, None, None),
             (0.1999, 100, True, None, None),
             (0.6, 101, False, None, None),

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -1022,10 +1022,10 @@ def _should_check_transcription(volunteer: BlossomUser) -> bool:
 
     # Otherwise, use their total gamma to determine the percentage
     probabilities = [
-        (5, 1),
-        (50, 0.4),
-        (100, 0.2),
-        (250, 0.1),
+        (10, 1),
+        (50, 0.5),
+        (100, 0.3),
+        (250, 0.15),
         (500, 0.05),
         (1000, 0.02),
         (5000, 0.01),

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -1032,7 +1032,7 @@ def _should_check_transcription(volunteer: BlossomUser) -> bool:
     ]
     for (gamma, probability) in probabilities:
         if volunteer.gamma <= gamma:
-            if random.random() < probability:
+            if random.random() <= probability:
                 return True
             else:
                 return False


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This updates the default check percentages, as quested by the QA team:

**Old**:
```
<=   5: 100%
<=  50:  40%
<= 100:  20%
<= 250:  10%
<= 500:   5%
<=1000:   2%
<=5000:   1%
> 5000:   0.5%
```
**New**:
```
<=  10: 100%
<=  50:  50%
<= 100:  30%
<= 250:  15%
<= 500:   5%
<=1000:   2%
<=5000:   1%
> 5000:   0.5%
```

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
