### PR TITLE
Fix transcription link not being picked up correctly

### DIFF
--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -91,7 +91,7 @@ def send_transcription_check(
 ) -> None:
     """Notify slack for the transcription check."""
     gamma = user.gamma
-    msg = f"*Transcription check* for u/{user.username} ({user.gamma:,d}):\n"
+    msg = f"*Transcription check* for u/{user.username} ({user.gamma:,d} Γ):\n"
 
     # Add relevant links
     tor_url = (

--- a/api/tests/test_slack.py
+++ b/api/tests/test_slack.py
@@ -575,7 +575,7 @@ def test_dadjoke_target(message: str) -> None:
             1,
             "url_stuff",
             "Low Activity",
-            "*Transcription check* for u/TESTosterone (1):\n"
+            "*Transcription check* for u/TESTosterone (1 Γ):\n"
             "<foo|ToR Post> | <bar|Partner Post> | <url_stuff|Transcription>\n"
             "Reason: Low Activity\n"
             ":rotating_light: First transcription! :rotating_light:",
@@ -584,7 +584,7 @@ def test_dadjoke_target(message: str) -> None:
             10,
             "url_stuff",
             "Watched (70.0%)",
-            "*Transcription check* for u/TESTosterone (10):\n"
+            "*Transcription check* for u/TESTosterone (10 Γ):\n"
             "<foo|ToR Post> | <bar|Partner Post> | <url_stuff|Transcription>\n"
             "Reason: Watched (70.0%)",
         ),
@@ -592,7 +592,7 @@ def test_dadjoke_target(message: str) -> None:
             20300,
             None,
             "Automatic (0.5%)",
-            "*Transcription check* for u/TESTosterone (20,300):\n"
+            "*Transcription check* for u/TESTosterone (20,300 Γ):\n"
             "<foo|ToR Post> | <bar|Partner Post> | [Removed]\n"
             "Reason: Automatic (0.5%)",
         ),

--- a/api/views/submission.py
+++ b/api/views/submission.py
@@ -561,7 +561,9 @@ class SubmissionViewSet(viewsets.ModelViewSet):
             if submission.claimed_by != user:
                 return Response(status=status.HTTP_412_PRECONDITION_FAILED)
 
-            transcription = Transcription.objects.filter(submission=submission).first()
+            transcription = Transcription.objects.filter(
+                submission=submission, author=user
+            ).first()
 
             if transcription is None:
                 return Response(status=status.HTTP_428_PRECONDITION_REQUIRED)


### PR DESCRIPTION
Relevant issue: Closes #361

## Description:

The OCR transcription got picked up instead of the user provided transcription.
It doesn't have a link, so `[Removed]` was displayed in the check message instead.

We now filter the transcription author to make sure that the correct one is selected.

Additionally this adds a `Γ` character to the user gamma in the check message.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
