### PR TITLE
Add watchstatus Slack command

### DIFF
--- a/api/slack/commands.py
+++ b/api/slack/commands.py
@@ -45,6 +45,7 @@ def process_command(data: Dict) -> None:
         "blacklist": blacklist_cmd,
         "watch": watch_cmd,
         "unwatch": unwatch_cmd,
+        "watchstatus": watchstatus_cmd,
         "watchlist": watchlist_cmd,
         "dadjoke": dadjoke_cmd,
     }
@@ -200,6 +201,29 @@ def unwatch_cmd(channel: str, message: str) -> None:
             user.save()
 
             msg = i18n["slack"]["unwatch"]["success"].format(user=user.username)
+        else:
+            msg = i18n["slack"]["errors"]["unknown_username"]
+
+    else:
+        msg = i18n["slack"]["errors"]["too_many_params"]
+
+    client.chat_postMessage(channel=channel, text=msg)
+
+
+def watchstatus_cmd(channel: str, message: str) -> None:
+    """Get the watch status of a specific user."""
+    parsed_message = message.split()
+
+    if len(parsed_message) == 1:
+        # they didn't give a username
+        msg = i18n["slack"]["errors"]["missing_username"]
+    elif len(parsed_message) == 2:
+        username = clean_links(parsed_message[1])
+        if user := BlossomUser.objects.filter(username__iexact=username).first():
+            status = user.transcription_check_reason(ignore_low_activity=True)
+            msg = i18n["slack"]["watchstatus"]["success"].format(
+                user=user.username, status=status
+            )
         else:
             msg = i18n["slack"]["errors"]["unknown_username"]
 

--- a/api/tests/test_slack.py
+++ b/api/tests/test_slack.py
@@ -21,6 +21,7 @@ from api.slack.commands import (
     unwatch_cmd,
     watch_cmd,
     watchlist_cmd,
+    watchstatus_cmd,
 )
 from api.slack.utils import dict_to_table, send_transcription_check
 from api.views.slack import github_sponsors_endpoint
@@ -541,6 +542,45 @@ def test_process_unwatch_error(message: str, response: str) -> None:
     test_user.refresh_from_db()
 
     assert test_user.overwrite_check_percentage is None
+    assert slack_client.chat_postMessage.call_args[1]["text"] == response
+
+
+def test_process_watchstatus() -> None:
+    """Test watchstatus functionality."""
+    slack_client.chat_postMessage = MagicMock()
+
+    test_user = create_user(username="u123", overwrite_check_percentage=0.5)
+    assert test_user.overwrite_check_percentage == 0.5
+
+    # process the message
+    watchstatus_cmd("", "watchstatus u123")
+    slack_client.chat_postMessage.assert_called_once()
+    test_user.refresh_from_db()
+    expected_message = i18n["slack"]["watchstatus"]["success"].format(
+        user=test_user.username, status="Watched (50.0%)"
+    )
+
+    assert slack_client.chat_postMessage.call_args[1]["text"] == expected_message
+
+
+@pytest.mark.parametrize(
+    "message,response",
+    [
+        ("watchstatus", i18n["slack"]["errors"]["missing_username"]),
+        ("watchstatus u123 50", i18n["slack"]["errors"]["too_many_params"]),
+    ],
+)
+def test_process_watchstatus_error(message: str, response: str) -> None:
+    """Test watch command for invalid messages."""
+    slack_client.chat_postMessage = MagicMock()
+
+    test_user = create_user(username="u123")
+
+    # process the message
+    watchstatus_cmd("", message)
+    slack_client.chat_postMessage.assert_called_once()
+    test_user.refresh_from_db()
+
     assert slack_client.chat_postMessage.call_args[1]["text"] == response
 
 

--- a/blossom/strings/en_US.toml
+++ b/blossom/strings/en_US.toml
@@ -35,14 +35,15 @@ messages = [
 help_message="""
 Help is on the way!
 
-Get information about a user: `@blossom info {username}`
-Get general server information: `@blossom info`
-Blacklist / unblacklist user: `@blossom blacklist {username}`
-Toggle CoC status of user: `@blossom reset {username}`
-Overwrite check percentage: `@blossom watch {username} {percentage}`, where {percentage} is a number between 0 and 100
-Reset check percentage: `@blossom unwatch {username}`
-List all overwritten check percentages: `@blossom watchlist {sorting}`, where {sorting} is either "percentage" (default) or "alphabetical".
-Render this message: `@blossom help`
+Get information about a user: `@Blossom info <username>`
+Get general server information: `@Blossom info`
+Blacklist / unblacklist user: `@Blossom blacklist <username>`
+Toggle CoC status of user: `@Blossom reset <username>`
+Overwrite check percentage: `@Blossom watch <username> <percentage>`, where `<percentage>` is a number between 0 and 100
+Reset check percentage: `@Blossom unwatch <username>`
+Get the check percentage for a user: `@Blossom watchlist <username>`
+List all overwritten check percentages: `@Blossom watchlist <sorting>`, where `<sorting>` is either "percentage" (default) or "alphabetical".
+Render this message: `@Blossom help`
 """
 
 server_summary="""
@@ -69,7 +70,7 @@ github_sponsor_update="{0} GitHub Sponsors: [{1}] - {2} | {3} {0}"
     empty_message_error="Sorry, I wasn't able to get text out of that. Try again."
     too_many_params="Too many parameters; please try again."
     no_user_by_that_name="Sorry, I wasn't able to find a user with that name."
-    missing_username="I don't see a username in your request -- make sure you're formatting your request as \"@blossom {action} {argument}\". Example: \"@blossom dadjoke @itsthejoker\""
+    missing_username="I don't see a username in your request -- make sure you're formatting your request as \"@Blossom {action} {argument}\". Example: \"@Blossom dadjoke @itsthejoker\""
     unknown_username="No username like that on file; please check your spelling."
     unknown_payload="Received unknown payload from Slack with key I don't recognize. Unknown key: {}"
 

--- a/blossom/strings/en_US.toml
+++ b/blossom/strings/en_US.toml
@@ -89,6 +89,9 @@ github_sponsor_update="{0} GitHub Sponsors: [{1}] - {2} | {3} {0}"
     [slack.unwatch]
     success="The chance to check transcriptions of {user} is now determined automatically."
 
+    [slack.watchstatus]
+    success="Watch status for {user}: {status}"
+
     [slack.dadjoke]
     message = "Hey {0}! {1}"
     fallback_joke = "Did you know that fortune tellers make their tents purple? They believe the color has mythical properties. It allows them to tell the fuschia."


### PR DESCRIPTION
Relevant issue: Closes #363

## Description:

Adds a new `watchstatus` Slack command, which will display the current check percentage for the given user.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
