### PR TITLE
Make find endpoint case-insensitive

### DIFF
--- a/api/tests/slack/test_commands.py
+++ b/api/tests/slack/test_commands.py
@@ -393,15 +393,22 @@ def test_dadjoke_target(message: str) -> None:
 @pytest.mark.parametrize(
     "url",
     [
+        # Normal URLs
         "https://reddit.com/r/TranscribersOfReddit/comments/t31715/curatedtumblr_image_linguistics_fax/",
         "https://reddit.com/r/CuratedTumblr/comments/t315gq/linguistics_fax/",
         "https://www.reddit.com/r/CuratedTumblr/comments/t315gq/linguistics_fax/hypuw2r/",
+        # Slack link
         "<https://reddit.com/r/TranscribersOfReddit/comments/t31715/curatedtumblr_image_linguistics_fax/>",
         "<https://reddit.com/r/CuratedTumblr/comments/t315gq/linguistics_fax/>",
         "<https://www.reddit.com/r/CuratedTumblr/comments/t315gq/linguistics_fax/hypuw2r/>",
+        # Named Slack link
         "<https://reddit.com/r/TranscribersOfReddit/comments/t31715/curatedtumblr_image_linguistics_fax/|Tor_Post>",
         "<https://reddit.com/r/CuratedTumblr/comments/t315gq/linguistics_fax/|Partner_Post>",
         "<https://www.reddit.com/r/CuratedTumblr/comments/t315gq/linguistics_fax/hypuw2r/|Transcription>",
+        # Wrong casing
+        "https://reddit.com/r/transcribersofreddit/comments/t31715/curatedtumblr_image_linguistics_fax/",
+        "https://reddit.com/r/curatedtumblr/comments/t315gq/linguistics_fax/",
+        "https://www.reddit.com/r/curatedtumblr/comments/t315gq/linguistics_fax/hypuw2r/",
     ],
 )
 def test_check_cmd(client: Client, url: str) -> None:

--- a/api/tests/test_find.py
+++ b/api/tests/test_find.py
@@ -227,6 +227,12 @@ def test_find_in_progress(client: Client, url: str, expected: bool) -> None:
             + "?utm_source=share&utm_medium=web2x&context=3",
             True,
         ),
+        # ToR comment URL lowercase
+        (
+            "https://www.reddit.com/r/transcribersofreddit/comments/q1tnhc/comment/hfgp1g7/"
+            + "?utm_source=share&utm_medium=web2x&context=3",
+            True,
+        ),
         # Transcription URL
         ("https://reddit.com/r/antiwork/comments/q1tlcf/comment/hfgp814/", True),
         # Shared transcription URL

--- a/api/views/find.py
+++ b/api/views/find.py
@@ -43,7 +43,7 @@ def normalize_url(reddit_url_str: str) -> Optional[str]:
 
 def find_by_submission_url(url: str, url_type: str) -> Optional[FindResponse]:
     """Find the objects by a submission URL."""
-    submissions = Submission.objects.filter(**{f"{url_type}__startswith": url})
+    submissions = Submission.objects.filter(**{f"{url_type}__istartswith": url})
     if submissions.count() == 0:
         return None
 


### PR DESCRIPTION
Relevant issue: Closes #368

## Description:

Make find endpoint case-insensitive. This should also fix the `check` command not recognizing links.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
