### PR TITLE
Fix check username detection

### DIFF
--- a/api/slack/transcription_check/actions.py
+++ b/api/slack/transcription_check/actions.py
@@ -4,10 +4,12 @@ from typing import Dict
 from django.utils import timezone
 
 from api.models import TranscriptionCheck
+from api.slack import client
 from api.slack.transcription_check.messages import (
     reply_to_action_with_ping,
     update_check_message,
 )
+from api.slack.utils import get_display_name
 from authentication.models import BlossomUser
 
 logger = logging.getLogger("api.slack.transcription_check.actions")
@@ -59,7 +61,7 @@ def process_check_action(data: Dict) -> None:
     parts = value.split("_")
     action = parts[1]
     check_id = parts[2]
-    mod_username = data["user"]["name"]
+    mod_username = get_display_name(client, data["user"])
 
     # Retrieve the corresponding objects form the DB
     check = TranscriptionCheck.objects.filter(id=check_id).first()

--- a/api/slack/transcription_check/messages.py
+++ b/api/slack/transcription_check/messages.py
@@ -49,7 +49,7 @@ def update_check_message(check: TranscriptionCheck) -> None:
 def reply_to_action(data: Dict, text: str) -> Dict:
     """Reply to the given action with the given text."""
     channel_id = data["channel"]["id"]
-    message_ts = data["message_ts"]
+    message_ts = data.get("message", {}).get("ts")
 
     return client.chat_postMessage(channel=channel_id, thread_ts=message_ts, text=text)
 

--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -138,3 +138,12 @@ def send_transcription_check(
         )
     except:  # noqa
         logger.warning(f"Cannot post message to slack. Msg: {msg}")
+
+
+def get_display_name(slack_client: WebClient, user: Dict) -> Optional[str]:
+    """Get the display name for the given user."""
+    response = slack_client.users_profile_get(user=user.get("id"))
+    if response.get("ok"):
+        return response.get("profile", {}).get("display_name")
+    else:
+        return None

--- a/api/tests/slack/transcription_check/test_actions.py
+++ b/api/tests/slack/transcription_check/test_actions.py
@@ -184,7 +184,10 @@ def test_process_check_action(client: Client) -> None:
 
     with patch(
         "api.slack.transcription_check.actions.update_check_message", return_value=None
-    ) as mock:
+    ) as mock, patch(
+        "api.slack.transcription_check.actions.get_display_name",
+        lambda _, us: us["name"],
+    ):
         process_check_action(data)
 
         check.refresh_from_db()
@@ -224,7 +227,10 @@ def test_process_check_action_unknown_check(client: Client) -> None:
     ) as update_mock, patch(
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
-    ) as reply_mock:
+    ) as reply_mock, patch(
+        "api.slack.transcription_check.actions.get_display_name",
+        lambda _, us: us["name"],
+    ):
         process_check_action(data)
 
         check.refresh_from_db()
@@ -263,7 +269,10 @@ def test_process_check_action_unknown_mod(client: Client) -> None:
     ) as update_mock, patch(
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
-    ) as reply_mock:
+    ) as reply_mock, patch(
+        "api.slack.transcription_check.actions.get_display_name",
+        lambda _, us: us["name"],
+    ):
         process_check_action(data)
 
         check.refresh_from_db()
@@ -308,7 +317,10 @@ def test_process_check_action_no_mod(client: Client) -> None:
     ) as update_mock, patch(
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
-    ) as reply_mock:
+    ) as reply_mock, patch(
+        "api.slack.transcription_check.actions.get_display_name",
+        lambda _, us: us["name"],
+    ):
         process_check_action(data)
 
         check.refresh_from_db()
@@ -353,7 +365,10 @@ def test_process_check_action_wrong_mod(client: Client) -> None:
     ) as update_mock, patch(
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
-    ) as reply_mock:
+    ) as reply_mock, patch(
+        "api.slack.transcription_check.actions.get_display_name",
+        lambda _, us: us["name"],
+    ):
         process_check_action(data)
 
         check.refresh_from_db()


### PR DESCRIPTION
Relevant issue: Closes #370

## Description:

- Get the mod username from the Slack profile instead of using the Slack username directly
- Fix `message_ts` value for `reply_to_action` function

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
