### PR TITLE
Update check on errors

### DIFF
--- a/api/slack/transcription_check/actions.py
+++ b/api/slack/transcription_check/actions.py
@@ -89,6 +89,8 @@ def process_check_action(data: Dict) -> None:
         reply_to_action_with_ping(
             data, f"Check {check_id} is already claimed by someone!"
         )
+        # Update to make sure the proper controls are shown
+        update_check_message(check)
         return
     # If it's not a claim it must already be claimed by someone
     if action != "claim" and check.moderator is None:
@@ -96,6 +98,8 @@ def process_check_action(data: Dict) -> None:
         reply_to_action_with_ping(
             data, f"Check {check_id} is not claimed by anyone yet!"
         )
+        # Update to make sure the proper controls are shown
+        update_check_message(check)
         return
     # If the action isn't a claim, the check must already be claimed
     if action != "claim" and check.moderator is None:
@@ -103,6 +107,8 @@ def process_check_action(data: Dict) -> None:
         reply_to_action_with_ping(
             data, f"Check {check_id} has not been claimed yet!",
         )
+        # Update to make sure the proper controls are shown
+        update_check_message(check)
         return
     # A claimed check can only be worked on by the mod who claimed it
     if action != "claim" and check.moderator != mod:
@@ -113,6 +119,8 @@ def process_check_action(data: Dict) -> None:
             data,
             f"Check {check_id} is claimed by u/{check.moderator.username}, not by you!",
         )
+        # Update to make sure the proper controls are shown
+        update_check_message(check)
         return
 
     # Try to update the DB model based on the action

--- a/api/slack/transcription_check/blocks.py
+++ b/api/slack/transcription_check/blocks.py
@@ -212,11 +212,12 @@ def construct_transcription_check_blocks(check: TranscriptionCheck) -> List[Dict
     base_text = _get_check_base_text(check)
     actions = _get_check_actions(check)
     status_text = _get_check_status_text(check)
+    text = f"{base_text}\n{status_text}"
 
     return [
         {
             "type": "section",
-            "text": {"type": "mrkdwn", "text": base_text},
+            "text": {"type": "mrkdwn", "text": text},
             "accessory": {
                 "type": "image",
                 "image_url": submission.content_url,
@@ -224,6 +225,5 @@ def construct_transcription_check_blocks(check: TranscriptionCheck) -> List[Dict
             },
         },
         {"type": "divider"},
-        {"type": "section", "text": {"type": "mrkdwn", "text": status_text}},
         {"type": "actions", "elements": actions},
     ]

--- a/api/tests/slack/transcription_check/test_actions.py
+++ b/api/tests/slack/transcription_check/test_actions.py
@@ -327,7 +327,7 @@ def test_process_check_action_no_mod(client: Client) -> None:
 
         assert check.status == CheckStatus.PENDING
         assert check.moderator is None
-        assert update_mock.call_count == 0
+        assert update_mock.call_count == 1
         assert reply_mock.call_count == 1
 
 
@@ -375,5 +375,5 @@ def test_process_check_action_wrong_mod(client: Client) -> None:
 
         assert check.status == CheckStatus.PENDING
         assert check.moderator == mod
-        assert update_mock.call_count == 0
+        assert update_mock.call_count == 1
         assert reply_mock.call_count == 1


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This PR updates the check message in some error cases (such as the check being unclaimed or already being claimed).
This makes sure that the proper buttons are shown, avoiding the check being stuck in an error state.

Additionally it moves the text around a bit to make the check message more compact.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
