### PR TITLE
Fix gamma counts in transcription checks

### DIFF
--- a/api/slack/transcription_check/blocks.py
+++ b/api/slack/transcription_check/blocks.py
@@ -1,14 +1,16 @@
 from typing import Dict, List
 
 from api.models import TranscriptionCheck
+from authentication.models import BlossomUser
 
 
 def _get_check_base_text(check: TranscriptionCheck) -> str:
     """Get basic info about the transcription check."""
     transcription = check.transcription
     submission = transcription.submission
-    user = transcription.author
-    gamma = user.gamma
+    user: BlossomUser = transcription.author
+    # Get the gamma at the time of the transcription that is checked
+    gamma = user.gamma_at_time(end_time=submission.complete_time)
 
     base_text = f"Transcription check for *u/{user.username}* ({gamma:,d} Γ):\n"
 

--- a/authentication/tests/test_blossomuser.py
+++ b/authentication/tests/test_blossomuser.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 from unittest.mock import PropertyMock, patch
 
@@ -11,6 +11,74 @@ from utils.test_helpers import (
     create_transcription,
     setup_user_client,
 )
+
+
+def test_gamma(client: Client) -> None:
+    """Test that a user's gamma is calculated correctly."""
+    client, headers, user = setup_user_client(client, id=123, username="Test")
+
+    times = [
+        datetime(2022, 3, 1),
+        datetime(2022, 3, 3),
+        datetime(2022, 4, 1),
+        datetime(2022, 5, 13),
+    ]
+
+    # Create the user's transcriptions
+    for time in times:
+        submission = create_submission(
+            create_time=time - timedelta(days=2),
+            claimed_by=user,
+            claim_time=time - timedelta(days=1),
+            completed_by=user,
+            complete_time=time,
+        )
+        create_transcription(submission=submission, user=user, create_time=time)
+
+    assert user.gamma == 4
+
+
+@pytest.mark.parametrize(
+    "start_time, end_time, expected",
+    [
+        (None, None, 4),
+        (datetime(2022, 3, 1), datetime(2022, 5, 13), 4),
+        (None, datetime(2022, 3, 13), 2),
+        (datetime(2022, 3, 2), None, 3),
+        (datetime(2022, 3, 2), datetime(2022, 3, 12), 1),
+        (datetime(2023, 1, 1), None, 0),
+        (None, datetime(2021, 1, 1), 0),
+    ],
+)
+def test_gamma_at_time(
+    client: Client,
+    start_time: Optional[datetime],
+    end_time: Optional[datetime],
+    expected: int,
+) -> None:
+    """Test that the gamma is calculated correctly for a time frame."""
+    client, headers, user = setup_user_client(client, id=123, username="Test")
+
+    times = [
+        datetime(2022, 3, 1),
+        datetime(2022, 3, 3),
+        datetime(2022, 4, 1),
+        datetime(2022, 5, 13),
+    ]
+
+    # Create the user's transcriptions
+    for time in times:
+        submission = create_submission(
+            create_time=time - timedelta(days=2),
+            claimed_by=user,
+            claim_time=time - timedelta(days=1),
+            completed_by=user,
+            complete_time=time,
+        )
+        create_transcription(submission=submission, user=user, create_time=time)
+
+    actual = user.gamma_at_time(start_time=start_time, end_time=end_time)
+    assert actual == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Relevant issue: Closes #379

## Description:

This PR fixes the gamma counts displayed in the transcription checks.
Previously, it just displayed the user's current gamma, which would become inaccurate as the message gets updated.

The new version calculates the user's gamma at the point of the transcription being checked. This is consistent and more intuitive.

:warning: The gamma counts might now be off for old users :warning:

For some old users, some submissions might be missing the `complete_time` field. These transcriptions might not be counted correctly.
However, for these users the gamma count is less important and we can fix the data in the future.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
