### PR TITLE
Get Reddit username through custom Slack profile field

### DIFF
--- a/api/slack/transcription_check/actions.py
+++ b/api/slack/transcription_check/actions.py
@@ -9,7 +9,7 @@ from api.slack.transcription_check.messages import (
     reply_to_action_with_ping,
     update_check_message,
 )
-from api.slack.utils import get_display_name
+from api.slack.utils import get_reddit_username
 from authentication.models import BlossomUser
 
 logger = logging.getLogger("api.slack.transcription_check.actions")
@@ -61,7 +61,7 @@ def process_check_action(data: Dict) -> None:
     parts = value.split("_")
     action = parts[1]
     check_id = parts[2]
-    mod_username = get_display_name(client, data["user"])
+    mod_username = get_reddit_username(client, data["user"])
 
     # Retrieve the corresponding objects form the DB
     check = TranscriptionCheck.objects.filter(id=check_id).first()

--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -140,10 +140,15 @@ def send_transcription_check(
         logger.warning(f"Cannot post message to slack. Msg: {msg}")
 
 
-def get_display_name(slack_client: WebClient, user: Dict) -> Optional[str]:
-    """Get the display name for the given user."""
+def get_reddit_username(slack_client: WebClient, user: Dict) -> Optional[str]:
+    """Get the Reddit username for the given Slack user."""
     response = slack_client.users_profile_get(user=user.get("id"))
     if response.get("ok"):
-        return response.get("profile", {}).get("display_name")
+        profile = response.get("profile", {})
+        # First try to get the username from the custom Slack field.
+        username = profile.get("Reddit Username")
+        # If this is not defined, take the display name instead.
+        display_name = profile.get("display_name")
+        return username or display_name
     else:
         return None

--- a/api/tests/slack/transcription_check/test_actions.py
+++ b/api/tests/slack/transcription_check/test_actions.py
@@ -185,7 +185,7 @@ def test_process_check_action(client: Client) -> None:
     with patch(
         "api.slack.transcription_check.actions.update_check_message", return_value=None
     ) as mock, patch(
-        "api.slack.transcription_check.actions.get_display_name",
+        "api.slack.transcription_check.actions.get_reddit_username",
         lambda _, us: us["name"],
     ):
         process_check_action(data)
@@ -221,7 +221,7 @@ def test_process_check_action_claim_own_transcription(client: Client) -> None:
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
     ) as reply_mock, patch(
-        "api.slack.transcription_check.actions.get_display_name",
+        "api.slack.transcription_check.actions.get_reddit_username",
         lambda _, us: us["name"],
     ):
         process_check_action(data)
@@ -265,7 +265,7 @@ def test_process_check_action_unknown_check(client: Client) -> None:
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
     ) as reply_mock, patch(
-        "api.slack.transcription_check.actions.get_display_name",
+        "api.slack.transcription_check.actions.get_reddit_username",
         lambda _, us: us["name"],
     ):
         process_check_action(data)
@@ -307,7 +307,7 @@ def test_process_check_action_unknown_mod(client: Client) -> None:
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
     ) as reply_mock, patch(
-        "api.slack.transcription_check.actions.get_display_name",
+        "api.slack.transcription_check.actions.get_reddit_username",
         lambda _, us: us["name"],
     ):
         process_check_action(data)
@@ -355,7 +355,7 @@ def test_process_check_action_no_mod(client: Client) -> None:
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
     ) as reply_mock, patch(
-        "api.slack.transcription_check.actions.get_display_name",
+        "api.slack.transcription_check.actions.get_reddit_username",
         lambda _, us: us["name"],
     ):
         process_check_action(data)
@@ -403,7 +403,7 @@ def test_process_check_action_wrong_mod(client: Client) -> None:
         "api.slack.transcription_check.actions.reply_to_action_with_ping",
         return_value={},
     ) as reply_mock, patch(
-        "api.slack.transcription_check.actions.get_display_name",
+        "api.slack.transcription_check.actions.get_reddit_username",
         lambda _, us: us["name"],
     ):
         process_check_action(data)


### PR DESCRIPTION
Relevant issue: Closes #380

## Description:

We introduced a custom "Reddit Username" field for the Slack profiles so that mods can set their username there instead of having to use the Slack display name.
This field is now used to pull the username, with the display name as fallback.

Note that the Slack documentation on the "fields" attribute are very sparse, so I might have to do some debugging in production to get this fully working.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [ ] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
