### PR TITLE
Migrate automatic transcription checks to the new check system

### DIFF
--- a/api/slack/transcription_check/blocks.py
+++ b/api/slack/transcription_check/blocks.py
@@ -71,7 +71,6 @@ def _get_check_pending_actions(check: TranscriptionCheck) -> List[Dict]:
         },
         {
             "type": "button",
-            "style": "danger",
             "text": {"type": "plain_text", "text": "Warn"},
             "value": f"check_warning-pending_{check.id}",
         },
@@ -107,12 +106,6 @@ def _get_check_comment_pending_actions(check: TranscriptionCheck) -> List[Dict]:
             "type": "button",
             "text": {"type": "plain_text", "text": "Revert"},
             "value": f"check_pending_{check.id}",
-        },
-        {
-            "type": "button",
-            "style": "danger",
-            "text": {"type": "plain_text", "text": "Warn"},
-            "value": f"check_warning-pending_{check.id}",
         },
         {
             "type": "button",

--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -129,7 +129,7 @@ def get_reddit_username(slack_client: WebClient, user: Dict) -> Optional[str]:
 
 def get_source(submission: Submission) -> str:
     """Extract the source from the given submission."""
-    if "reddit.com" in submission.url:
+    if submission.url and "reddit.com" in submission.url:
         return "r/" + submission.url.split("/")[4]
     else:
         return submission.source.name

--- a/api/tests/slack/test_utils.py
+++ b/api/tests/slack/test_utils.py
@@ -15,7 +15,6 @@ from api.slack.utils import (
     extract_url_from_link,
     get_reddit_username,
     get_source,
-    send_transcription_check,
 )
 from blossom.strings import translation
 from utils.test_helpers import (
@@ -78,56 +77,6 @@ def test_slack_neat_printer(test_data: Dict) -> None:
     """Verify that the neat printer formats tables appropriately."""
     result = dict_to_table(**test_data["data"])
     assert result == test_data["result"]
-
-
-@pytest.mark.parametrize(
-    "gamma, tr_url, reason, message",
-    [
-        (
-            1,
-            "url_stuff",
-            "Low Activity",
-            "*Transcription check* for u/TESTosterone (1 Γ):\n"
-            "<foo|ToR Post> | <bar|Partner Post> | <url_stuff|Transcription>\n"
-            "Reason: Low Activity\n"
-            ":rotating_light: First transcription! :rotating_light:",
-        ),
-        (
-            10,
-            "url_stuff",
-            "Watched (70.0%)",
-            "*Transcription check* for u/TESTosterone (10 Γ):\n"
-            "<foo|ToR Post> | <bar|Partner Post> | <url_stuff|Transcription>\n"
-            "Reason: Watched (70.0%)",
-        ),
-        (
-            20300,
-            None,
-            "Automatic (0.5%)",
-            "*Transcription check* for u/TESTosterone (20,300 Γ):\n"
-            "<foo|ToR Post> | <bar|Partner Post> | [Removed]\n"
-            "Reason: Automatic (0.5%)",
-        ),
-    ],
-)
-def test_send_transcription_to_slack(
-    client: Client, gamma: int, tr_url: str, reason: str, message: str,
-) -> None:
-    """Test the transcription check message."""
-    # Patch a bunch of properties to get consistent output
-    with patch(
-        "authentication.models.BlossomUser.gamma",
-        new_callable=PropertyMock,
-        return_value=gamma,
-    ), patch("api.slack.client.chat_postMessage", new_callable=MagicMock) as mock:
-        client, headers, user = setup_user_client(client, username="TESTosterone")
-        submission = create_submission(tor_url="foo", url="bar", claimed_by=user)
-        transcription = create_transcription(submission, user, url=tr_url)
-
-        send_transcription_check(transcription, submission, user, slack_client, reason)
-
-        actual_message = mock.call_args[1]["text"]
-        assert actual_message == message
 
 
 @pytest.mark.parametrize(

--- a/api/tests/slack/test_utils.py
+++ b/api/tests/slack/test_utils.py
@@ -220,6 +220,7 @@ def test_get_reddit_username(user_obj: Dict, expected: Optional[str]) -> None:
             Submission(url="https://example.com", source=Source(name="blossom")),
             "blossom",
         ),
+        (Submission(url=None, source=Source(name="blossom")), "blossom",),
     ],
 )
 def test_get_source(submission: Submission, expected: str) -> None:

--- a/api/tests/submissions/test_submission_done.py
+++ b/api/tests/submissions/test_submission_done.py
@@ -24,12 +24,13 @@ class TestSubmissionDone:
         create_transcription(submission, user)
         data = {"username": user.username}
 
-        result = client.patch(
-            reverse("submission-done", args=[submission.id]),
-            json.dumps(data),
-            content_type="application/json",
-            **headers,
-        )
+        with patch("api.views.submission.send_check_message"):
+            result = client.patch(
+                reverse("submission-done", args=[submission.id]),
+                json.dumps(data),
+                content_type="application/json",
+                **headers,
+            )
 
         submission.refresh_from_db()
         assert result.status_code == status.HTTP_201_CREATED
@@ -137,7 +138,7 @@ class TestSubmissionDone:
         with patch(
             "authentication.models.BlossomUser.should_check_transcription",
             return_value=should_check_transcription,
-        ), patch("api.views.submission.send_transcription_check") as mock:
+        ), patch("api.views.submission.send_check_message") as mock:
             client, headers, user = setup_user_client(client)
             submission = create_submission(url="abc", tor_url="def", claimed_by=user)
             create_transcription(submission, user, url="ghi")

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -366,10 +366,13 @@ class TestTranscribeSubmission:
         )
         assert submission.completed_by is None
 
-        response = client.post(
-            reverse("transcribe_submission", kwargs={"submission_id": submission.id}),
-            data={"transcription": "AAA"},
-        )
+        with patch("api.views.submission.send_check_message"):
+            response = client.post(
+                reverse(
+                    "transcribe_submission", kwargs={"submission_id": submission.id}
+                ),
+                data={"transcription": "AAA"},
+            )
 
         submission.refresh_from_db()
         assert reverse("choose_transcription") in response.url
@@ -425,10 +428,17 @@ class TestTranscribeSubmission:
             title="a",
             claimed_by=user,
         )
-        client.post(
-            reverse("transcribe_submission", kwargs={"submission_id": submission.id}),
-            data={"transcription": "u/aaa ! Check this out!\n```\nabcde\n```\n\nayy"},
-        )
+
+        with patch("api.views.submission.send_check_message"):
+            client.post(
+                reverse(
+                    "transcribe_submission", kwargs={"submission_id": submission.id}
+                ),
+                data={
+                    "transcription": "u/aaa ! Check this out!\n```\nabcde\n```\n\nayy"
+                },
+            )
+
         assert "`" not in Transcription.objects.first().text
         assert "\\/" in Transcription.objects.first().text
 


### PR DESCRIPTION
Relevant issue: Closes #330

## Description:

This PR migrates the automatic transcription checks to the new button-based system (used by the `check` Slack command).

It also includes some minor changes to the button workflow, removing the "Warn" button in the comment pending state and using the default style for the "Warn" button.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
