### PR TITLE
388 slack fallback text

### DIFF
--- a/api/slack/transcription_check/messages.py
+++ b/api/slack/transcription_check/messages.py
@@ -17,11 +17,15 @@ def _construct_transcription_check_text(check: TranscriptionCheck) -> str:
     This text is displayed in notifications.
     """
     transcription = check.transcription
-    user = transcription.author.username
-    source = get_source(transcription.submission)
+    submission = transcription.submission
+    user = transcription.author
+
+    username = user.username
+    gamma = user.gamma_at_time(end_time=submission.complete_time)
+    source = get_source(submission)
     trigger = check.trigger
 
-    return f"Check for u/{user} on {source} | {trigger}"
+    return f"Check for u/{username} ({gamma} Γ) on {source} | {trigger}"
 
 
 def send_check_message(

--- a/api/tests/slack/transcription_check/test_messages.py
+++ b/api/tests/slack/transcription_check/test_messages.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import Optional
+from unittest.mock import patch
+
+from django.test import Client
+
+from api.models import Source, TranscriptionCheck
+from api.slack.transcription_check.messages import _construct_transcription_check_text
+from utils.test_helpers import (
+    create_check,
+    create_submission,
+    create_transcription,
+    create_user,
+    setup_user_client,
+)
+
+
+def test_construct_transcription_check_text(client: Client) -> None:
+    """Test that the fallback text is generated correctly."""
+    client, _headers, user = setup_user_client(client, id=100, username="Userson")
+    mod = create_user(id=200, username="Moddington")
+    submission = create_submission(
+        claimed_by=user,
+        completed_by=user,
+        # flake8: noqa: E501
+        url="https://www.reddit.com/r/CuratedTumblr/comments/tirg5d/surviving_a_sitcom_death_mention/",
+        source=Source(name="reddit"),
+    )
+    transcription = create_transcription(submission=submission, user=user)
+    check = create_check(transcription, moderator=mod, trigger="Watched (100.0%)")
+
+    expected = "Check for u/Userson on r/CuratedTumblr | Watched (100.0%)"
+    actual = _construct_transcription_check_text(check)
+
+    assert actual == expected


### PR DESCRIPTION
Relevant issue: Closes #388

## Description:

This PR adds a fallback text for transcription check messages which is displayed in notifications.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
