### PR TITLE
Accept bold usernames in commands

### DIFF
--- a/api/slack/commands.py
+++ b/api/slack/commands.py
@@ -97,10 +97,10 @@ def info_cmd(channel: str, message: str) -> None:
         if user:
             v_data = VolunteerSerializer(user).data
             msg = i18n["slack"]["user_info"].format(
-                user.username, "\n".join(dict_to_table(v_data))
+                username, "\n".join(dict_to_table(v_data))
             )
         else:
-            msg = i18n["slack"]["errors"]["no_user_by_that_name"]
+            msg = i18n["slack"]["errors"]["unknown_username"].format(username=username)
     else:
         msg = i18n["slack"]["errors"]["too_many_params"]
 
@@ -130,7 +130,7 @@ def reset_cmd(channel: str, message: str) -> None:
                 user.save()
                 msg = i18n["slack"]["reset_coc"]["success_undo"].format(username)
         else:
-            msg = i18n["slack"]["errors"]["unknown_username"]
+            msg = i18n["slack"]["errors"]["unknown_username"].format(username=username)
 
     else:
         msg = i18n["slack"]["errors"]["too_many_params"]
@@ -186,7 +186,7 @@ def watch_cmd(channel: str, message: str) -> None:
                     user=username, percentage=decimal_percentage, previous=previous
                 )
         else:
-            msg = i18n["slack"]["errors"]["unknown_username"]
+            msg = i18n["slack"]["errors"]["unknown_username"].format(username=username)
 
     else:
         msg = i18n["slack"]["errors"]["too_many_params"]
@@ -210,7 +210,7 @@ def unwatch_cmd(channel: str, message: str) -> None:
 
             msg = i18n["slack"]["unwatch"]["success"].format(user=username)
         else:
-            msg = i18n["slack"]["errors"]["unknown_username"]
+            msg = i18n["slack"]["errors"]["unknown_username"].format(username=username)
 
     else:
         msg = i18n["slack"]["errors"]["too_many_params"]
@@ -233,7 +233,7 @@ def watchstatus_cmd(channel: str, message: str) -> None:
                 user=username, status=status
             )
         else:
-            msg = i18n["slack"]["errors"]["unknown_username"]
+            msg = i18n["slack"]["errors"]["unknown_username"].format(username=username)
 
     else:
         msg = i18n["slack"]["errors"]["too_many_params"]
@@ -342,7 +342,7 @@ def blacklist_cmd(channel: str, message: str) -> None:
                 user.save()
                 msg = i18n["slack"]["blacklist"]["success"].format(username)
         else:
-            msg = i18n["slack"]["errors"]["unknown_username"]
+            msg = i18n["slack"]["errors"]["unknown_username"].format(username=username)
     else:
         msg = i18n["slack"]["errors"]["too_many_params"]
 

--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from slack import WebClient
 
 from api.models import Submission
+from authentication.models import BlossomUser
 from blossom.strings import translation
 
 logger = logging.getLogger("api.slack.utils")
@@ -74,6 +75,16 @@ def parse_username(text: str) -> str:
         username = prefix_match.group("username")
 
     return username
+
+
+def parse_user(text: str) -> Optional[BlossomUser]:
+    """Parse a username argument of a Slack command to a user object.
+
+    This takes care of link formatting, bold formatting and the u/ prefix.
+    Returns `None` if the user couldn't be found.
+    """
+    username = parse_username(text)
+    return BlossomUser.objects.filter(username=username).first()
 
 
 def dict_to_table(dictionary: Dict, titles: List = None, width: int = None) -> List:

--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -22,6 +22,8 @@ SLACK_TEXT_EXTRACTOR = re.compile(
     r"<(?P<url>(?:https?://)?[\w-]+(?:\.[\w-]+)+\.?(?::\d+)?(?:/[^\s|]*)?)(?:\|(?P<text>[^>]+))?>"
 )
 
+BOLD_REGEX = re.compile(r"\*(?P<content>[^*]+)\*")
+
 USERNAME_REGEX = re.compile(r"(?:/?u/)?(?P<username>\S+)")
 
 
@@ -51,6 +53,27 @@ def extract_url_from_link(text: str) -> str:
     for match in results:
         text = text[: match.start()] + extract_link(match) + text[match.end() :]
     return text
+
+
+def parse_username(text: str) -> str:
+    """Parse a username argument of a Slack command.
+
+    This takes care of link formatting, bold formatting and the u/ prefix.
+    """
+    # Remove link formatting
+    username = extract_text_from_link(text)
+
+    # Remove bold formatting
+    bold_match = BOLD_REGEX.match(username)
+    if bold_match:
+        username = bold_match.group("content")
+
+    # Remove u/ prefix
+    prefix_match = USERNAME_REGEX.match(username)
+    if prefix_match:
+        username = prefix_match.group("username")
+
+    return username
 
 
 def dict_to_table(dictionary: Dict, titles: List = None, width: int = None) -> List:

--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from re import Match
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from django.conf import settings
 from slack import WebClient
@@ -56,10 +56,11 @@ def extract_url_from_link(text: str) -> str:
     return text
 
 
-def parse_username(text: str) -> str:
-    """Parse a username argument of a Slack command.
+def parse_user(text: str) -> Tuple[Optional[BlossomUser], str]:
+    """Parse a username argument of a Slack command to a user object.
 
     This takes care of link formatting, bold formatting and the u/ prefix.
+    Returns `None` if the user couldn't be found.
     """
     # Remove link formatting
     username = extract_text_from_link(text)
@@ -74,17 +75,10 @@ def parse_username(text: str) -> str:
     if prefix_match:
         username = prefix_match.group("username")
 
-    return username
+    # Try to fetch the given user
+    user = BlossomUser.objects.filter(username=username).first()
 
-
-def parse_user(text: str) -> Optional[BlossomUser]:
-    """Parse a username argument of a Slack command to a user object.
-
-    This takes care of link formatting, bold formatting and the u/ prefix.
-    Returns `None` if the user couldn't be found.
-    """
-    username = parse_username(text)
-    return BlossomUser.objects.filter(username=username).first()
+    return user, username
 
 
 def dict_to_table(dictionary: Dict, titles: List = None, width: int = None) -> List:

--- a/api/slack/utils.py
+++ b/api/slack/utils.py
@@ -78,6 +78,10 @@ def parse_user(text: str) -> Tuple[Optional[BlossomUser], str]:
     # Try to fetch the given user
     user = BlossomUser.objects.filter(username=username).first()
 
+    # Fix capitalization if user has been found
+    if user:
+        username = user.username
+
     return user, username
 
 

--- a/api/tests/slack/test_commands.py
+++ b/api/tests/slack/test_commands.py
@@ -71,7 +71,10 @@ def test_process_blacklist_with_slack_link() -> None:
     "message,response",
     [
         ("blacklist", i18n["slack"]["errors"]["missing_username"]),
-        ("blacklist asdf", i18n["slack"]["errors"]["unknown_username"]),
+        (
+            "blacklist asdf",
+            i18n["slack"]["errors"]["unknown_username"].format(username="asdf"),
+        ),
         ("a b c", i18n["slack"]["errors"]["too_many_params"]),
     ],
 )
@@ -127,7 +130,10 @@ def test_process_coc_reset_with_slack_link() -> None:
     "message,response",
     [
         ("reset", i18n["slack"]["errors"]["missing_username"]),
-        ("reset asdf", i18n["slack"]["errors"]["unknown_username"]),
+        (
+            "reset asdf",
+            i18n["slack"]["errors"]["unknown_username"].format(username="asdf"),
+        ),
         ("reset a b c", i18n["slack"]["errors"]["too_many_params"]),
     ],
 )
@@ -178,7 +184,10 @@ def test_process_watch(message: str, percentage: float) -> None:
     [
         ("watch", i18n["slack"]["errors"]["missing_username"]),
         ("watch u123 50 13", i18n["slack"]["errors"]["too_many_params"]),
-        ("watch u456 50", i18n["slack"]["errors"]["unknown_username"]),
+        (
+            "watch u456 50",
+            i18n["slack"]["errors"]["unknown_username"].format(username="u456"),
+        ),
         (
             "watch u123 -1",
             i18n["slack"]["watch"]["invalid_percentage"].format(percentage="-1"),

--- a/api/tests/slack/test_utils.py
+++ b/api/tests/slack/test_utils.py
@@ -140,6 +140,12 @@ def test_extract_url_from_link(text: str, expected: str) -> None:
         ("*<https://reddit.com/u/user123|user123>*", "user123", True),
         ("*<https://reddit.com/u/user123|u/user123>*", "user123", True),
         ("*<https://reddit.com/u/user123|/u/user123>*", "user123", True),
+        # Correct capitalization
+        ("/u/USeR123", "user123", True),
+        ("*usER123*", "user123", True),
+        # Invalid username
+        ("user456", "user456", False),
+        ("*/u/user456*", "user456", False),
     ],
 )
 def test_parse_user(client: Client, text: str, username: str, found: bool) -> None:

--- a/api/tests/slack/test_utils.py
+++ b/api/tests/slack/test_utils.py
@@ -15,6 +15,7 @@ from api.slack.utils import (
     extract_url_from_link,
     get_reddit_username,
     get_source,
+    parse_user,
     parse_username,
 )
 from blossom.strings import translation
@@ -152,6 +153,26 @@ def test_parse_username(text: str, expected: str) -> None:
     """Test that a username is parsed correctly."""
     actual = parse_username(text)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # No formatting
+        ("user123", True),
+        ("*u/user123*", True),
+        ("USER123", True),
+        ("user567", False),
+    ],
+)
+def test_parse_user(client: Client, text: str, expected: bool) -> None:
+    """Test that a username is parsed correctly."""
+    client, headers, user = setup_user_client(client, id=100, username="user123")
+    actual = parse_user(text)
+    if expected:
+        assert actual == user
+    else:
+        assert actual is None
 
 
 @pytest.mark.parametrize(

--- a/api/tests/slack/test_utils.py
+++ b/api/tests/slack/test_utils.py
@@ -15,6 +15,7 @@ from api.slack.utils import (
     extract_url_from_link,
     get_reddit_username,
     get_source,
+    parse_username,
 )
 from blossom.strings import translation
 from utils.test_helpers import (
@@ -120,6 +121,36 @@ def test_extract_text_from_link(text: str, expected: str) -> None:
 def test_extract_url_from_link(text: str, expected: str) -> None:
     """Test that the URL is extracted from a Slack link."""
     actual = extract_url_from_link(text)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # No formatting
+        ("user123", "user123"),
+        ("u/user123", "user123"),
+        ("/u/user123", "user123"),
+        # Link
+        ("<https://reddit.com/u/user123|user123>", "user123"),
+        ("<https://reddit.com/u/user123|u/user123>", "user123"),
+        ("<https://reddit.com/u/user123|/u/user123>", "user123"),
+        # Bold
+        ("*user123*", "user123"),
+        ("*u/user123*", "user123"),
+        ("*/u/user123*", "user123"),
+        # Link + Bold
+        ("<https://reddit.com/u/user123|*user123*>", "user123"),
+        ("<https://reddit.com/u/user123|*u/user123*>", "user123"),
+        ("<https://reddit.com/u/user123|*/u/user123*>", "user123"),
+        ("*<https://reddit.com/u/user123|user123>*", "user123"),
+        ("*<https://reddit.com/u/user123|u/user123>*", "user123"),
+        ("*<https://reddit.com/u/user123|/u/user123>*", "user123"),
+    ],
+)
+def test_parse_username(text: str, expected: str) -> None:
+    """Test that a username is parsed correctly."""
+    actual = parse_username(text)
     assert actual == expected
 
 

--- a/blossom/strings/en_US.toml
+++ b/blossom/strings/en_US.toml
@@ -65,44 +65,43 @@ User info for {0}:
 
 github_sponsor_update="{0} GitHub Sponsors: [{1}] - {2} | {3} {0}"
 
-    [slack.errors]
-    unknown_request="Sorry, I'm not sure what you're asking for."
-    message_parse_error="Sorry, something went wrong and I couldn't parse your message."
-    empty_message_error="Sorry, I wasn't able to get text out of that. Try again."
-    too_many_params="Too many parameters; please try again."
-    no_user_by_that_name="Sorry, I wasn't able to find a user with that name."
-    missing_username="I don't see a username in your request -- make sure you're formatting your request as \"@Blossom {action} {argument}\". Example: \"@Blossom dadjoke @itsthejoker\""
-    unknown_username="No username like that on file; please check your spelling."
-    unknown_payload="Received unknown payload from Slack with key I don't recognize. Unknown key: {}"
+[slack.errors]
+unknown_request="Sorry, I'm not sure what you're asking for."
+message_parse_error="Sorry, something went wrong and I couldn't parse your message."
+empty_message_error="Sorry, I wasn't able to get text out of that. Try again."
+too_many_params="Too many parameters; please try again."
+missing_username="I don't see a username in your request -- make sure you're formatting your request as \"@Blossom {action} {argument}\". Example: \"@Blossom dadjoke @itsthejoker\""
+unknown_username="Sorry, I couldn't find a user with the name `u/{username}`. Please check your spelling."
+unknown_payload="Received unknown payload from Slack with key I don't recognize. Unknown key: {}"
 
-    [slack.blacklist]
-    success="User '{0}' blacklisted."
-    success_undo="User '{0}' unblacklisted."
+[slack.blacklist]
+success="User '{0}' blacklisted."
+success_undo="User '{0}' unblacklisted."
 
-    [slack.reset_coc]
-    success="Code of Conduct acceptance revoked for user '{0}'."
-    success_undo="Code of Conduct acceptance approved for user '{0}'."
+[slack.reset_coc]
+success="Code of Conduct acceptance revoked for user '{0}'."
+success_undo="Code of Conduct acceptance approved for user '{0}'."
 
-    [slack.watch]
-    invalid_percentage="{percentage} is an invalid percentage. Please provide a number between 0 and 100, such as '50%' or '75'."
-    percentage_too_low="Sorry, you can't set the percentage lower than the automatic check percentage for this user ({auto_percentage:.1%})!"
-    success="The transcriptions of {user} now have a {percentage:.0%} chance to be checked.\nPreviously: {previous}.\nUse `unwatch {user}` to undo this."
+[slack.watch]
+invalid_percentage="{percentage} is an invalid percentage. Please provide a number between 0 and 100, such as '50%' or '75'."
+percentage_too_low="Sorry, you can't set the percentage lower than the automatic check percentage for this user ({auto_percentage:.1%})!"
+success="The transcriptions of {user} now have a {percentage:.0%} chance to be checked.\nPreviously: {previous}.\nUse `unwatch {user}` to undo this."
 
-    [slack.unwatch]
-    success="The chance to check transcriptions of {user} is now determined automatically."
+[slack.unwatch]
+success="The chance to check transcriptions of {user} is now determined automatically."
 
-    [slack.watchstatus]
-    success="Watch status for {user}: {status}"
+[slack.watchstatus]
+success="Watch status for {user}: {status}"
 
-    [slack.dadjoke]
-    message = "Hey {0}! {1}"
-    fallback_joke = "Did you know that fortune tellers make their tents purple? They believe the color has mythical properties. It allows them to tell the fuschia."
+[slack.dadjoke]
+message = "Hey {0}! {1}"
+fallback_joke = "Did you know that fortune tellers make their tents purple? They believe the color has mythical properties. It allows them to tell the fuschia."
 
-    [slack.check]
-    success="Generated <{check_url}|a check> for <{tr_url}|this transcription> by u/{username}!"
-    already_checked="There's already <{check_url}|a check> for <{tr_url}|this transcription> by u/{username}!"
-    failed_to_send="Sorry, there was a problem sending the check to Slack!"
-    no_url="You need to provide a Reddit URL to generate a check for! Use `@Blossom check <url>`."
-    invalid_url="Sorry, `{url}` is not a valid Reddit URL. Please provide a Reddit link to a ToR post, partner post or transcription."
-    no_submission="Sorry, I couldn't find a submission for the URL `{url}`!"
-    no_transcription="<{tor_url}|The post> does not have a transcription yet!"
+[slack.check]
+success="Generated <{check_url}|a check> for <{tr_url}|this transcription> by u/{username}!"
+already_checked="There's already <{check_url}|a check> for <{tr_url}|this transcription> by u/{username}!"
+failed_to_send="Sorry, there was a problem sending the check to Slack!"
+no_url="You need to provide a Reddit URL to generate a check for! Use `@Blossom check <url>`."
+invalid_url="Sorry, `{url}` is not a valid Reddit URL. Please provide a Reddit link to a ToR post, partner post or transcription."
+no_submission="Sorry, I couldn't find a submission for the URL `{url}`!"
+no_transcription="<{tor_url}|The post> does not have a transcription yet!"


### PR DESCRIPTION
Relevant issue: Closes #381

## Description:

This PR improves and simplifies the username parsing for the Slack commands. All commands should now accept usernames with various formatting, including links, bold text and the u/ prefix.

Additionally, if the user could not be found, the parsed username is now included in the error message for easier debugging.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
