### PR TITLE
Only trigger bump-version on PRs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,8 +1,8 @@
 name: Bump Version Number
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    branches: [ master ]
+    types: [ opened ]
 
 jobs:
   run:
@@ -37,3 +37,8 @@ jobs:
           committer_name: GitHub Actions
           committer_email: actions@github.com
           add: 'pyproject.toml'
+        continue-on-error: true
+
+      # https://github.com/actions/toolkit/issues/399#issuecomment-1058231820
+      - name: Allow failures
+        run: true

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,6 +4,9 @@ on:
     branches: [ master ]
     types: [ opened ]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GRAFEAS_GH_PAT }}
+
 jobs:
   run:
     name: Bump Version Number

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blossom"
-version = "1.66.0"
+version = "1.67.0"
 description = "The site!"
 authors = ["Grafeas Group Ltd. <devs@grafeas.org>"]
 


### PR DESCRIPTION
## Description:

Just moves the bump-version command to run on PRs instead of on push to master. Been using it this way on a different project and it's much nicer. Also fails cleanly now.