### PR TITLE
Rework the Slack `info` command

### DIFF
--- a/api/slack/commands/info.py
+++ b/api/slack/commands/info.py
@@ -45,8 +45,9 @@ def user_info_text(user: BlossomUser) -> str:
     """Get the info message for the given user."""
     general = user_general_info(user)
     transcription_quality = user_transcription_quality_info(user)
+    debug = user_debug_info(user)
 
-    return f"TODO\n{general}\n{transcription_quality}"
+    return f"TODO\n{general}\n{transcription_quality}\n{debug}"
 
 
 def user_general_info(user: BlossomUser) -> Dict:
@@ -94,6 +95,26 @@ def user_transcription_quality_info(user: BlossomUser) -> Dict:
         "Warnings": warnings,
         "Watch status": watch_status,
     }
+
+
+def user_debug_info(user: BlossomUser) -> Dict:
+    """Get debug info about the given user."""
+    user_id = f"`{user.id}`"
+    blacklisted = bool_str(user.blacklisted)
+    bot = bool_str(user.is_bot)
+    accepted_coc = bool_str(user.accepted_coc)
+
+    return {
+        "ID": user_id,
+        "Blacklisted": blacklisted,
+        "Bot": bot,
+        "Accepted CoC": accepted_coc,
+    }
+
+
+def bool_str(bl: bool) -> str:
+    """Convert a bool to a Yes/No string."""
+    return "Yes" if bl else "No"
 
 
 def _format_time(time: datetime) -> str:

--- a/api/slack/commands/info.py
+++ b/api/slack/commands/info.py
@@ -1,7 +1,13 @@
+from datetime import datetime, timedelta
+from typing import Dict
+
+from django.utils import timezone
+
 from api.serializers import VolunteerSerializer
 from api.slack import client
 from api.slack.utils import dict_to_table, parse_user
 from api.views.misc import Summary
+from authentication.models import BlossomUser
 from blossom.strings import translation
 
 i18n = translation()
@@ -32,3 +38,80 @@ def info_cmd(channel: str, message: str) -> None:
         msg = i18n["slack"]["errors"]["too_many_params"]
 
     client.chat_postMessage(channel=channel, text=msg)
+
+
+def user_info_text(user: BlossomUser) -> str:
+    """Get the info message for the given user."""
+    general = user_general_info(user)
+
+    return f"TODO\n{general}"
+
+
+def user_general_info(user: BlossomUser) -> Dict:
+    """Get general info for the given user."""
+    total_gamma = user.gamma
+    recent_gamma = user.gamma_at_time(start_time=timezone.now() - timedelta(weeks=2))
+    gamma = f"{total_gamma} Γ ({recent_gamma} Γ in last 2 weeks)"
+    joined_on = _format_time(user.date_joined)
+    last_active = _format_time(user.date_last_active())
+
+    return {
+        "Gamma": gamma,
+        "Joined on": joined_on,
+        "Last active": last_active,
+    }
+
+
+def _format_time(time: datetime) -> str:
+    """Format the given time in absolute and relative strings."""
+    now = timezone.now()
+    absolute = time.date().isoformat()
+
+    relative_delta = now - time
+    relative = _relative_duration(relative_delta)
+
+    if now >= time:
+        return f"{absolute} ({relative} ago)"
+    else:
+        return f"{absolute} (in {relative})"
+
+
+def _relative_duration(delta: timedelta) -> str:
+    """Format the delta into a relative time string."""
+    seconds = abs(delta.total_seconds())
+    minutes = seconds / 60
+    hours = minutes / 60
+    days = hours / 24
+    weeks = days / 7
+    months = days / 30
+    years = days / 365
+
+    # Determine major time unit
+    if years >= 1:
+        value, unit = years, "year"
+    elif months >= 1:
+        value, unit = months, "month"
+    elif weeks >= 1:
+        value, unit = weeks, "week"
+    elif days >= 1:
+        value, unit = days, "day"
+    elif hours >= 1:
+        value, unit = hours, "hour"
+    elif minutes >= 1:
+        value, unit = minutes, "min"
+    elif seconds > 5:
+        value, unit = seconds, "sec"
+    else:
+        duration_ms = seconds / 1000
+        value, unit = duration_ms, "ms"
+
+    if unit == "ms":
+        duration_str = f"{value:0.0f} ms"
+    else:
+        # Add plural s if necessary
+        if value != 1:
+            unit += "s"
+
+        duration_str = f"{value:.1f} {unit}"
+
+    return duration_str

--- a/api/tests/slack/commands/test_info.py
+++ b/api/tests/slack/commands/test_info.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytz
+from django.test import Client
+
+from api.models import TranscriptionCheck
+from api.slack.commands.info import user_info_text
+from utils.test_helpers import (
+    create_check,
+    create_submission,
+    create_transcription,
+    setup_user_client,
+)
+
+
+def test_user_info_text_new_user(client: Client) -> None:
+    """Verify that the string for a new user is generated correctly."""
+    client, headers, user = setup_user_client(
+        client,
+        id=123,
+        username="Userson",
+        date_joined=datetime(2021, 5, 21, tzinfo=pytz.UTC),
+        accepted_coc=False,
+        is_bot=False,
+    )
+
+    expected = """Info about *<https://reddit.com/u/Userson|u/Userson>*:
+
+*General*:
+- Gamma: 0 Γ (0 Γ in last 2 weeks)
+- Joined on: 2021-05-21 (1.0 day ago)
+- Last active: Never
+
+*Transcription Quality*:
+- Checks: 0 (0.0% of transcriptions)
+- Warnings: 0 (0.0% of checks)
+- Watch status: Automatic (100.0%)
+
+*Debug Info*:
+- ID: `123`
+- Blacklisted: No
+- Bot: No
+- Accepted CoC: No"""
+
+    with patch(
+        "api.slack.commands.info.timezone.now",
+        return_value=datetime(2021, 5, 22, tzinfo=pytz.UTC),
+    ):
+        actual = user_info_text(user)
+
+    assert actual == expected
+
+
+def test_user_info_text_old_user(client: Client) -> None:
+    """Verify that the string for a new user is generated correctly."""
+    client, headers, user = setup_user_client(
+        client,
+        id=123,
+        username="Userson",
+        date_joined=datetime(2020, 4, 21, tzinfo=pytz.UTC),
+        accepted_coc=True,
+        is_bot=False,
+    )
+
+    tr_data = [
+        (datetime(2020, 7, 3, tzinfo=pytz.UTC), True, False),
+        (datetime(2020, 7, 7, tzinfo=pytz.UTC), False, False),
+        (datetime(2020, 7, 9, tzinfo=pytz.UTC), False, False),
+        (datetime(2021, 4, 10, tzinfo=pytz.UTC), True, True),
+        (datetime(2021, 4, 12, tzinfo=pytz.UTC), False, False),
+    ]
+
+    for idx, (date, has_check, is_warning) in enumerate(tr_data):
+        submission = create_submission(
+            id=100 + idx,
+            create_time=date - timedelta(days=1),
+            claim_time=date,
+            complete_time=date + timedelta(days=1),
+            claimed_by=user,
+            completed_by=user,
+        )
+        transcription = create_transcription(
+            submission, user, id=200 + idx, create_time=date
+        )
+
+        if has_check:
+            check_status = TranscriptionCheck.TranscriptionCheckStatus
+            status = (
+                check_status.WARNING_RESOLVED if is_warning else check_status.APPROVED
+            )
+            create_check(transcription, status=status)
+
+    expected = """Info about *<https://reddit.com/u/Userson|u/Userson>*:
+
+*General*:
+- Gamma: 5 Γ (2 Γ in last 2 weeks)
+- Joined on: 2020-04-21 (1.0 year ago)
+- Last active: 2021-04-13 (1.1 weeks ago)
+
+*Transcription Quality*:
+- Checks: 2 (40.0% of transcriptions)
+- Warnings: 1 (50.0% of checks)
+- Watch status: Automatic (100.0%)
+
+*Debug Info*:
+- ID: `123`
+- Blacklisted: No
+- Bot: No
+- Accepted CoC: Yes"""
+
+    with patch(
+        "api.slack.commands.info.timezone.now",
+        return_value=datetime(2021, 4, 21, tzinfo=pytz.UTC),
+    ):
+        actual = user_info_text(user)
+
+    assert actual == expected

--- a/blossom/strings/en_US.toml
+++ b/blossom/strings/en_US.toml
@@ -56,14 +56,6 @@ Here's a status update on everything!
 ```
 """
 
-user_info="""
-User info for {0}:
-
-```
-{1}
-```
-"""
-
 github_sponsor_update="{0} GitHub Sponsors: [{1}] - {2} | {3} {0}"
 
 [slack.errors]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blossom"
-version = "1.71.0"
+version = "1.72.0"
 description = "The site!"
 authors = ["Grafeas Group Ltd. <devs@grafeas.org>"]
 


### PR DESCRIPTION
Relevant issue: Closes #404

## Description:

This is a complete rework of the `info` command in Slack, providing more data and formatting it in a more readable way.

Example output:

---

Info about **[u/Userson](https://reddit.com/u/Userson)**:

**General**:
- Gamma: 5 Γ (2 Γ in last 2 weeks)
- Joined on: 2020-04-21 (1.0 year ago)
- Last active: 2021-04-13 (1.1 weeks ago)

**Transcription Quality**:
- Checks: 2 (40.0% of transcriptions)
- Warnings: 1 (50.0% of checks)
- Watch status: Automatic (100.0%)

**Debug Info**:
- ID: `123`
- Blacklisted: No
- Bot: No
- Accepted CoC: Yes

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
