### PR TITLE
Add comment count and percentage to info command

### DIFF
--- a/api/slack/commands/info.py
+++ b/api/slack/commands/info.py
@@ -90,6 +90,18 @@ def user_transcription_quality_info(user: BlossomUser) -> Dict:
     check_ratio = check_count / gamma if gamma > 0 else 0
     checks = f"{check_count} ({check_ratio:.1%} of transcriptions)"
 
+    # The comments for the given user
+    user_comments_pending = user_checks.filter(status=check_status.COMMENT_PENDING)
+    user_comments_resolved = user_checks.filter(status=check_status.COMMENT_RESOLVED)
+    user_comments_unfixed = user_checks.filter(status=check_status.COMMENT_UNFIXED)
+    comments_count = (
+        user_comments_pending.count()
+        + user_comments_resolved.count()
+        + user_comments_unfixed.count()
+    )
+    comments_ratio = comments_count / check_count if check_count > 0 else 0
+    comments = f"{comments_count} ({comments_ratio:.1%} of checks)"
+
     # The warnings for the given user
     user_warnings_pending = user_checks.filter(status=check_status.WARNING_PENDING)
     user_warnings_resolved = user_checks.filter(status=check_status.WARNING_RESOLVED)
@@ -102,11 +114,13 @@ def user_transcription_quality_info(user: BlossomUser) -> Dict:
     warnings_ratio = warnings_count / check_count if check_count > 0 else 0
     warnings = f"{warnings_count} ({warnings_ratio:.1%} of checks)"
 
+    # Watch status
     watch_status = user.transcription_check_reason(ignore_low_activity=True)
 
     return {
         "Checks": checks,
         "Warnings": warnings,
+        "Comments": comments,
         "Watch status": watch_status,
     }
 

--- a/api/tests/slack/commands/test_info.py
+++ b/api/tests/slack/commands/test_info.py
@@ -35,6 +35,7 @@ def test_user_info_text_new_user(client: Client) -> None:
 *Transcription Quality*:
 - Checks: 0 (0.0% of transcriptions)
 - Warnings: 0 (0.0% of checks)
+- Comments: 0 (0.0% of checks)
 - Watch status: Automatic (100.0%)
 
 *Debug Info*:
@@ -64,14 +65,14 @@ def test_user_info_text_old_user(client: Client) -> None:
     )
 
     tr_data = [
-        (datetime(2020, 7, 3, tzinfo=pytz.UTC), True, False),
-        (datetime(2020, 7, 7, tzinfo=pytz.UTC), False, False),
-        (datetime(2020, 7, 9, tzinfo=pytz.UTC), False, False),
-        (datetime(2021, 4, 10, tzinfo=pytz.UTC), True, True),
-        (datetime(2021, 4, 12, tzinfo=pytz.UTC), False, False),
+        (datetime(2020, 7, 3, tzinfo=pytz.UTC), True, True, False),
+        (datetime(2020, 7, 7, tzinfo=pytz.UTC), False, False, False),
+        (datetime(2020, 7, 9, tzinfo=pytz.UTC), False, False, False),
+        (datetime(2021, 4, 10, tzinfo=pytz.UTC), True, False, True),
+        (datetime(2021, 4, 12, tzinfo=pytz.UTC), True, False, False),
     ]
 
-    for idx, (date, has_check, is_warning) in enumerate(tr_data):
+    for idx, (date, has_check, is_comment, is_warning) in enumerate(tr_data):
         submission = create_submission(
             id=100 + idx,
             create_time=date - timedelta(days=1),
@@ -87,7 +88,11 @@ def test_user_info_text_old_user(client: Client) -> None:
         if has_check:
             check_status = TranscriptionCheck.TranscriptionCheckStatus
             status = (
-                check_status.WARNING_RESOLVED if is_warning else check_status.APPROVED
+                check_status.COMMENT_RESOLVED
+                if is_comment
+                else check_status.WARNING_RESOLVED
+                if is_warning
+                else check_status.APPROVED
             )
             create_check(transcription, status=status)
 
@@ -99,8 +104,9 @@ def test_user_info_text_old_user(client: Client) -> None:
 - Last active: 2021-04-13 (1.1 weeks ago)
 
 *Transcription Quality*:
-- Checks: 2 (40.0% of transcriptions)
-- Warnings: 1 (50.0% of checks)
+- Checks: 3 (60.0% of transcriptions)
+- Warnings: 1 (33.3% of checks)
+- Comments: 1 (33.3% of checks)
 - Watch status: Automatic (100.0%)
 
 *Debug Info*:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blossom"
-version = "1.72.0"
+version = "1.73.0"
 description = "The site!"
 authors = ["Grafeas Group Ltd. <devs@grafeas.org>"]
 


### PR DESCRIPTION
Relevant issue: Closes #406

## Description:

Adds the number of check comments for the user and the percentage in relation to the total checks.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
