### PR TITLE
Link to Reddit profiles in transcription check messages

### DIFF
--- a/api/slack/transcription_check/blocks.py
+++ b/api/slack/transcription_check/blocks.py
@@ -25,9 +25,12 @@ def _get_check_base_text(check: TranscriptionCheck) -> str:
     post_url = "<{}|Partner Post>".format(submission.url) if submission.url else "[N/A]"
     transcription_url = (
         "<{}|Transcription>".format(transcription.url)
-        if transcription.url and not transcription.removed_from_reddit
+        if transcription.url
         else "[Removed]"
     )
+    if transcription.removed_from_reddit and transcription.url:
+        transcription_url += " [Removed]"
+
     source = get_source(submission)
     details = [tor_url, post_url, transcription_url, source]
     # Indicate if the post is NSFW

--- a/api/slack/transcription_check/blocks.py
+++ b/api/slack/transcription_check/blocks.py
@@ -10,11 +10,13 @@ def _get_check_base_text(check: TranscriptionCheck) -> str:
     transcription = check.transcription
     submission = transcription.submission
     user: BlossomUser = transcription.author
+    username = user.username
+    user_link = f"<https://reddit.com/u/{username}?sort=new|u/{username}>"
     is_nsfw = submission.nsfw
     # Get the gamma at the time of the transcription that is checked
     gamma = user.gamma_at_time(end_time=submission.complete_time)
 
-    base_text = f"Transcription check for *u/{user.username}* ({gamma:,d} Γ):\n"
+    base_text = f"Transcription check for *{user_link}* ({gamma:,d} Γ):\n"
 
     # Add relevant links
     tor_url = (


### PR DESCRIPTION
Relevant issue: Closes #411

## Description:

The transcription check messages now:
- Link to the Reddit profile of the user.
- Show the transcription link even if it is marked as removed.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
