### PR TITLE
update workflow to modern python

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,22 +5,18 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.9]
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout current branch
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10.x
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
-    - uses: snok/install-poetry@v1.1.1
+        python-version: 3.10.x
+    - uses: snok/install-poetry@v1
       with:
         virtualenvs-create: true
     - name: Install Dependencies


### PR DESCRIPTION
Relevant issue: https://github.com/GrafeasGroup/blossom/pull/447

## Description:

The static analysis test is failing because it's an old-ass version of python. This updates the workflow to be less stuck in time.