### PR TITLE
Fix Reddit flair update on unclaim command

### DIFF
--- a/blossom/api/slack/actions/unclaim.py
+++ b/blossom/api/slack/actions/unclaim.py
@@ -121,5 +121,5 @@ def _process_unclaim_cancel(
 
 def _unclaim_reddit_flair(submission: Submission) -> None:
     """Update the Reddit flair of the submission to indicate that it's unclaimed."""
-    r_tor_submission: SubmissionModeration = REDDIT.submission(submission.tor_url).mod()
+    r_tor_submission: SubmissionModeration = REDDIT.submission(submission.tor_url).mod
     r_tor_submission.flair.select(flair_template_id=UNCLAIM_REDDIT_FLAIR_ID)


### PR DESCRIPTION
Relevant issue: N/A

## Description:

From the logs:

```
r_tor_submission: SubmissionModeration = REDDIT.submission(submission.tor_url).mod()
 TypeError: 'SubmissionModeration' object is not callable
```

The joys of dynamic typing :smiling_face_with_tear: 

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
