### PR TITLE
Fix date_last_active returning None too often

### DIFF
--- a/blossom/authentication/models.py
+++ b/blossom/authentication/models.py
@@ -114,12 +114,14 @@ class BlossomUser(AbstractUser):
         This will give the time where the user last claimed or completed a post.
         """
         recently_claimed = (
-            Submission.objects.filter(claimed_by=self).order_by("-claim_time").first()
+            Submission.objects.filter(claimed_by=self, claim_time__isnull=False)
+            .order_by("-claim_time")
+            .first()
         )
         recent_claim_time = recently_claimed.claim_time if recently_claimed else None
 
         recently_completed = (
-            Submission.objects.filter(completed_by=self)
+            Submission.objects.filter(completed_by=self, complete_time__isnull=False)
             .order_by("-complete_time")
             .first()
         )


### PR DESCRIPTION
Relevant issue: #464

## Description:

It now correctly filters out None entries for claim_time and complete_time.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
