### PR TITLE
Exclude local settings file from flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,6 @@ import-order-style = pycharm
 max-complexity = 10
 max-line-length = 90
 use-varnames-strict-mode = true
-exclude =  .git,__pycache__,build,dist,.venv,blossom/bootstrap/*,*/migrations/*,docker/*
+exclude =  .git,__pycache__,build,dist,.venv,blossom/bootstrap/*,*/migrations/*,docker/*,./local_settings.py
 per-file-ignores =
     blossom/settings/routing.py:F401,F403


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Exclude the local settings file from flake8 checks as it is not committed.
