### PR TITLE
Add filters for submission feed to transcription view

### DIFF
--- a/blossom/api/views/submission.py
+++ b/blossom/api/views/submission.py
@@ -148,7 +148,7 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         "content_url": ["exact", "isnull"],
         "redis_id": ["exact", "isnull"],
         "removed_from_queue": ["exact"],
-        "feed": ["exact", "isnull", "iexact"],
+        "feed": ["exact", "iexact", "icontains", "isnull"],
     }
     ordering_fields = [
         "id",

--- a/blossom/api/views/transcription.py
+++ b/blossom/api/views/transcription.py
@@ -32,6 +32,7 @@ class TranscriptionViewSet(viewsets.ModelViewSet):
     filterset_fields = {
         "id": ["exact"],
         "submission": ["exact"],
+        "submission__feed": ["exact", "iexact", "icontains", "isnull"],
         "author": ["exact"],
         "original_id": ["exact", "isnull"],
         "source": ["exact"],


### PR DESCRIPTION
Relevant issue: Preparation for <https://github.com/GrafeasGroup/buttercup/issues/202>.

## Description:

Adds additional `submission__feed__*` filters to the transcription view.
This enables us to efficiently filter by subreddits for Buttercup commands and other functionality.

## Checklist:

- [x] Code Quality
- [x] Tests (if applicable)
- [x] Inline Documentation
