### PR TITLE
Add check stats for all mods combined

### DIFF
--- a/blossom/api/slack/commands/checkstats.py
+++ b/blossom/api/slack/commands/checkstats.py
@@ -1,10 +1,10 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Dict
 
 from django.db.models import Q, QuerySet
 from django.utils import timezone
 
-from blossom.api.models import TranscriptionCheck
+from blossom.api.models import Submission, TranscriptionCheck
 from blossom.api.slack import client
 from blossom.api.slack.commands.utils import format_stats_section, format_time
 from blossom.api.slack.utils import parse_user
@@ -18,6 +18,18 @@ CheckStatus = TranscriptionCheck.TranscriptionCheckStatus
 # Timedelta for all "recent" queries
 RECENT_DELTA = timedelta(weeks=2)
 
+WARNING_FILTER = (
+    Q(status=CheckStatus.WARNING_PENDING)
+    | Q(status=CheckStatus.WARNING_RESOLVED)
+    | Q(status=CheckStatus.WARNING_UNFIXED)
+)
+
+COMMENT_FILTER = (
+    Q(status=CheckStatus.COMMENT_PENDING)
+    | Q(status=CheckStatus.COMMENT_RESOLVED)
+    | Q(status=CheckStatus.COMMENT_UNFIXED)
+)
+
 
 def checkstats_cmd(channel: str, message: str) -> None:
     """Get the check stats for a specific mod.
@@ -29,11 +41,11 @@ def checkstats_cmd(channel: str, message: str) -> None:
 
     if len(parsed_message) == 1:
         # they didn't give a username
-        msg = i18n["slack"]["errors"]["missing_username"]
+        msg = check_stats_all_msg()
     elif len(parsed_message) == 2:
         user, username = parse_user(parsed_message[1])
         if user:
-            msg = check_stats_msg(user)
+            msg = check_stats_mod_msg(user)
         else:
             msg = i18n["slack"]["errors"]["unknown_username"].format(username=username)
 
@@ -43,7 +55,7 @@ def checkstats_cmd(channel: str, message: str) -> None:
     client.chat_postMessage(channel=channel, text=msg)
 
 
-def check_stats_msg(mod: BlossomUser) -> str:
+def check_stats_mod_msg(mod: BlossomUser) -> str:
     """Get the message showing the check stats for the given mod."""
     recent_date = timezone.now() - RECENT_DELTA
 
@@ -110,13 +122,8 @@ def _warning_check_stats(
     recent_mod_checks: QuerySet,
 ) -> Dict:
     """Get the stats for the warning checks."""
-    warning_filter = (
-        Q(status=CheckStatus.WARNING_PENDING)
-        | Q(status=CheckStatus.WARNING_RESOLVED)
-        | Q(status=CheckStatus.WARNING_UNFIXED)
-    )
-    server_warnings = server_checks.filter(warning_filter)
-    mod_warnings = mod_checks.filter(warning_filter)
+    server_warnings = server_checks.filter(WARNING_FILTER)
+    mod_warnings = mod_checks.filter(WARNING_FILTER)
 
     # All time warnings
     server_warning_count = server_warnings.count()
@@ -129,8 +136,8 @@ def _warning_check_stats(
     )
 
     # Recent warnings
-    recent_server_warning_count = recent_server_checks.filter(warning_filter).count()
-    recent_mod_warning_count = recent_mod_checks.filter(warning_filter).count()
+    recent_server_warning_count = recent_server_checks.filter(WARNING_FILTER).count()
+    recent_mod_warning_count = recent_mod_checks.filter(WARNING_FILTER).count()
     recent_warning_ratio_checks = _get_ratio(recent_mod_warning_count, recent_mod_checks.count())
     recent_warning_ratio_all = _get_ratio(recent_mod_warning_count, recent_server_warning_count)
     recent_warning_msg = (
@@ -158,13 +165,8 @@ def _comment_check_stats(
     recent_mod_checks: QuerySet,
 ) -> Dict:
     """Get the stats for the comment checks."""
-    comment_filter = (
-        Q(status=CheckStatus.COMMENT_PENDING)
-        | Q(status=CheckStatus.COMMENT_RESOLVED)
-        | Q(status=CheckStatus.COMMENT_UNFIXED)
-    )
-    server_comments = server_checks.filter(comment_filter)
-    mod_comments = mod_checks.filter(comment_filter)
+    server_comments = server_checks.filter(COMMENT_FILTER)
+    mod_comments = mod_checks.filter(COMMENT_FILTER)
 
     # All time comments
     server_comment_count = server_comments.count()
@@ -177,8 +179,8 @@ def _comment_check_stats(
     )
 
     # Recent comments
-    recent_server_comment_count = recent_server_checks.filter(comment_filter).count()
-    recent_mod_comment_count = recent_mod_checks.filter(comment_filter).count()
+    recent_server_comment_count = recent_server_checks.filter(COMMENT_FILTER).count()
+    recent_mod_comment_count = recent_mod_checks.filter(COMMENT_FILTER).count()
     recent_comment_ratio_checks = _get_ratio(recent_mod_comment_count, recent_mod_checks.count())
     recent_comment_ratio_all = _get_ratio(recent_mod_comment_count, recent_server_comment_count)
     recent_comment_msg = (
@@ -197,6 +199,120 @@ def _comment_check_stats(
         "Last 2 weeks": recent_comment_msg,
         "Last completed": last_comment_msg,
     }
+
+
+def check_stats_all_msg() -> str:
+    """Get the check stats for all mods together."""
+    now = datetime.now(tz=timezone.utc)
+
+    one_day_ago = now - timedelta(days=1)
+    one_week_ago = now - timedelta(weeks=1)
+    one_month_ago = now - timedelta(days=30)
+    one_year_ago = now - timedelta(days=365)
+
+    # Transcriptions
+
+    query_transcribed_all = Submission.objects.filter(
+        removed_from_queue=False, completed_by__isnull=False
+    )
+
+    transcribed_all = query_transcribed_all.count()
+    transcribed_one_day = query_transcribed_all.filter(complete_time__gte=one_day_ago).count()
+    transcribed_one_week = query_transcribed_all.filter(complete_time__gte=one_week_ago).count()
+    transcribed_one_month = query_transcribed_all.filter(complete_time__gte=one_month_ago).count()
+    transcribed_one_year = query_transcribed_all.filter(complete_time__gte=one_year_ago).count()
+
+    query_checks_all = TranscriptionCheck.objects.filter(complete_time__isnull=False)
+
+    # Checks
+
+    checks_all = query_checks_all.count()
+    checks_percentage_all = _get_ratio(checks_all, transcribed_all)
+    checks_one_day = query_checks_all.filter(complete_time__gte=one_day_ago).count()
+    checks_percentage_one_day = _get_ratio(checks_one_day, transcribed_one_day)
+    checks_one_week = query_checks_all.filter(complete_time__gte=one_week_ago).count()
+    checks_percentage_one_week = _get_ratio(checks_one_week, transcribed_one_week)
+    checks_one_month = query_checks_all.filter(complete_time__gte=one_month_ago).count()
+    checks_percentage_one_month = _get_ratio(checks_one_month, transcribed_one_month)
+    checks_one_year = query_checks_all.filter(complete_time__gte=one_year_ago).count()
+    checks_percentage_one_year = _get_ratio(checks_one_year, transcribed_one_year)
+
+    check_info = i18n["slack"]["checkstats"]["check_info"].format(
+        checks_all=checks_all,
+        checks_percentage_all=checks_percentage_all,
+        checks_one_day=checks_one_day,
+        checks_percentage_one_day=checks_percentage_one_day,
+        checks_week_day=checks_one_week,
+        checks_percentage_one_week=checks_percentage_one_week,
+        checks_one_month=checks_one_month,
+        checks_percentage_one_month=checks_percentage_one_month,
+        checks_one_year=checks_one_year,
+        checks_percentage_one_year=checks_percentage_one_year,
+    )
+
+    # Warnings
+
+    query_warnings_all = query_checks_all.filter(WARNING_FILTER)
+
+    warnings_all = query_warnings_all.count()
+    warnings_percentage_all = _get_ratio(warnings_all, checks_all)
+    warnings_one_day = query_warnings_all.filter(complete_time__gte=one_day_ago).count()
+    warnings_percentage_one_day = _get_ratio(warnings_one_day, checks_one_day)
+    warnings_one_week = query_warnings_all.filter(complete_time__gte=one_week_ago).count()
+    warnings_percentage_one_week = _get_ratio(warnings_one_week, checks_one_week)
+    warnings_one_month = query_warnings_all.filter(complete_time__gte=one_month_ago).count()
+    warnings_percentage_one_month = _get_ratio(warnings_one_month, checks_one_month)
+    warnings_one_year = query_warnings_all.filter(complete_time__gte=one_year_ago).count()
+    warnings_percentage_one_year = _get_ratio(warnings_one_year, checks_one_year)
+
+    warning_info = i18n["slack"]["checkstats"]["warning_info"].format(
+        warnings_all=warnings_all,
+        warnings_percentage_all=warnings_percentage_all,
+        warnings_one_day=warnings_one_day,
+        warnings_percentage_one_day=warnings_percentage_one_day,
+        warnings_week_day=warnings_one_week,
+        warnings_percentage_one_week=warnings_percentage_one_week,
+        warnings_one_month=warnings_one_month,
+        warnings_percentage_one_month=warnings_percentage_one_month,
+        warnings_one_year=warnings_one_year,
+        warnings_percentage_one_year=warnings_percentage_one_year,
+    )
+
+    # Comments
+
+    query_comments_all = query_checks_all.filter(COMMENT_FILTER)
+
+    comments_all = query_comments_all.count()
+    comments_percentage_all = _get_ratio(comments_all, checks_all)
+    comments_one_day = query_comments_all.filter(complete_time__gte=one_day_ago).count()
+    comments_percentage_one_day = _get_ratio(comments_one_day, checks_one_day)
+    comments_one_week = query_comments_all.filter(complete_time__gte=one_week_ago).count()
+    comments_percentage_one_week = _get_ratio(comments_one_week, checks_one_week)
+    comments_one_month = query_comments_all.filter(complete_time__gte=one_month_ago).count()
+    comments_percentage_one_month = _get_ratio(comments_one_month, checks_one_month)
+    comments_one_year = query_comments_all.filter(complete_time__gte=one_year_ago).count()
+    comments_percentage_one_year = _get_ratio(comments_one_year, checks_one_year)
+
+    comment_info = i18n["slack"]["checkstats"]["comment_info"].format(
+        comments_all=comments_all,
+        comments_percentage_all=comments_percentage_all,
+        comments_one_day=comments_one_day,
+        comments_percentage_one_day=comments_percentage_one_day,
+        comments_week_day=comments_one_week,
+        comments_percentage_one_week=comments_percentage_one_week,
+        comments_one_month=comments_one_month,
+        comments_percentage_one_month=comments_percentage_one_month,
+        comments_one_year=comments_one_year,
+        comments_percentage_one_year=comments_percentage_one_year,
+    )
+
+    # Putting it together
+
+    return i18n["slack"]["checkstats"]["message"].format(
+        check_info=check_info,
+        warning_info=warning_info,
+        comment_info=comment_info,
+    )
 
 
 def _get_ratio(value: float, total: float) -> float:

--- a/blossom/api/tests/slack/commands/test_checkstats.py
+++ b/blossom/api/tests/slack/commands/test_checkstats.py
@@ -5,7 +5,7 @@ import pytz
 from django.test import Client
 
 from blossom.api.models import TranscriptionCheck
-from blossom.api.slack.commands.checkstats import check_stats_msg
+from blossom.api.slack.commands.checkstats import check_stats_mod_msg
 from blossom.utils.test_helpers import (
     create_check,
     create_submission,
@@ -85,6 +85,6 @@ def test_check_stats_msg(client: Client) -> None:
         "blossom.api.slack.commands.checkstats.timezone.now",
         return_value=datetime(2020, 7, 23, tzinfo=pytz.UTC),
     ):
-        actual = check_stats_msg(mod)
+        actual = check_stats_mod_msg(mod)
 
     assert actual == expected

--- a/blossom/strings/en_US.toml
+++ b/blossom/strings/en_US.toml
@@ -165,3 +165,30 @@ transcription_info="""*Transcriptions*:
 - Total: {transcribed_sub:,g} ({transcribed_percentage_transcriptions:.2%} of transcriptions, {transcribed_percentage_sub_submissions:.2%} of sub submissions)"""
 volunteer_info="""*Volunteers*:
 - Total: {volunteers_sub:,g} ({volunteer_percentage:.2%} of volunteers)"""
+
+[slack.checkstats]
+message="""Mod check stats for *everyone*:
+
+{check_info}
+
+{warning_info}
+
+{comment_info}"""
+check_info="""*Completed Checks*:
+- Total: {checks_all:,g} ({checks_percentage_all:.2%} of transcriptions)
+- Last day: {checks_one_day:,g} ({checks_percentage_one_day:.2%} of transcriptions)
+- Last week: {checks_one_week:,g} ({checks_percentage_one_week:.2%} of transcriptions)
+- Last month: {checks_one_month:,g} ({checks_percentage_one_month:.2%} of transcriptions)
+- Last year: {checks_one_year:,g} ({checks_percentage_one_year:.2%} of transcriptions)"""
+warning_info="""*Completed Warnings*:
+- Total: {warnings_all:,g} ({warnings_percentage_all:.2%} of checks)
+- Last day: {warnings_one_day:,g} ({warnings_percentage_one_day:.2%} of checks)
+- Last week: {warnings_one_week:,g} ({warnings_percentage_one_week:.2%} of checks)
+- Last month: {warnings_one_month:,g} ({warnings_percentage_one_month:.2%} of checks)
+- Last year: {warnings_one_year:,g} ({warnings_percentage_one_year:.2%} of checks)"""
+comment_info="""*Completed Comments*:
+- Total: {comments_all:,g} ({comments_percentage_all:.2%} of checks)
+- Last day: {comments_one_day:,g} ({comments_percentage_one_day:.2%} of checks)
+- Last week: {comments_one_week:,g} ({comments_percentage_one_week:.2%} of checks)
+- Last month: {comments_one_month:,g} ({comments_percentage_one_month:.2%} of checks)
+- Last year: {comments_one_year:,g} ({comments_percentage_one_year:.2%} of checks)"""


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This PR extends the `checkstats` command if no mod is provided.
In this case, the stats for all mods combined are displayed.

## Checklist:

- [x] Code Quality
- [ ] Tests (if applicable)
- [x] Inline Documentation
