### PR TITLE
Fix wrong transcription counts in check messages

### DIFF
--- a/blossom/authentication/models.py
+++ b/blossom/authentication/models.py
@@ -159,7 +159,14 @@ class BlossomUser(AbstractUser):
         if end_time:
             filters["complete_time__lte"] = end_time
 
-        return Submission.objects.filter(**filters).count()
+        timed_gamma = Submission.objects.filter(**filters).count()
+
+        # Old users might not have times for the completion
+        untimed_gamma = Submission.objects.filter(
+            completed_by=self, complete_time__isnull=True
+        ).count()
+
+        return timed_gamma + untimed_gamma
 
     def __str__(self) -> str:
         return self.username

--- a/blossom/authentication/models.py
+++ b/blossom/authentication/models.py
@@ -162,9 +162,11 @@ class BlossomUser(AbstractUser):
         timed_gamma = Submission.objects.filter(**filters).count()
 
         # Old users might not have times for the completion
-        untimed_gamma = Submission.objects.filter(
-            completed_by=self, complete_time__isnull=True
-        ).count()
+        untimed_gamma = (
+            0
+            if start_time is None and end_time is None
+            else Submission.objects.filter(completed_by=self, complete_time__isnull=True).count()
+        )
 
         return timed_gamma + untimed_gamma
 


### PR DESCRIPTION
Relevant issue: N/A

## Description:

For some old users, the gamma in the transcription check messages was off (by a lot).
This is probably because some old posts don't have completion times for the submissions.

The `gamma_at_time` method now also includes completed submissions without a time in the count.

## Checklist:

- [x] Code Quality
- [ ] Tests (if applicable)
- [x] Inline Documentation
